### PR TITLE
[FIX] otools-addon: crash

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
     "cookiecutter",
     "click",
     "importlib_resources; python_version < '3.9'",
+    "requirements-parser",
 ]
 requires-python = ">=3.8"
 dynamic = ["version"]
@@ -52,7 +53,6 @@ otools-addon = "odoo_tools.addon:cli"
 test = [
   "coverage",
   "pytest",
-  "requirements-parser",
   "responses",
 ]
 


### PR DESCRIPTION
otools-addon would crash because of missing dependency on
requirements-parser -> fix the pyproject.toml file.
