### PR TITLE
FIX: otools-addon add: filter by odoo serie

### DIFF
--- a/odoo_tools/cli/addon.py
+++ b/odoo_tools/cli/addon.py
@@ -50,11 +50,11 @@ def add(name, version=None, pr=None, odoo=True, upgrade=False):
       latest version of the module on PyPI and use that version
 
     * Otherwise:
+
         * if the version is the same, do nothing. Otherwise, prompt the user
         * If the addon is present as a PR, prompt the user
 
     """
-    # TODO: get odoo version from project
     # TODO: centralize printing/logging in `ui` utils
     click.secho(f"Adding: {name}", fg="green")
     pkg = Package(name, odoo=odoo)
@@ -118,7 +118,11 @@ def add_pending(ref, addons=None, editable=True, aggregate=True):
         run(f"touch {dev_req_file_path.as_posix()}")
 
     for name in addons:
-        pkg = Package(name, odoo=True, req_filepath=dev_req_file_path)
+        pkg = Package(
+            name,
+            odoo=True,
+            req_filepath=dev_req_file_path,
+        )
         # TODO: does it work w/ commits?
         pkg.add_or_replace_requirement(pr=ref, editable=editable)
 

--- a/odoo_tools/utils/pkg.py
+++ b/odoo_tools/utils/pkg.py
@@ -2,6 +2,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 
 from . import pypi, req
+from .proj import get_current_version
 
 
 class Package:
@@ -11,8 +12,9 @@ class Package:
         self.pypi_name = name
         self.req_filepath = req_filepath
         if self.odoo:
-            self.pypi_name = pypi.odoo_name_to_pkg_name(name)
-        self.latest_version = pypi.get_last_pypi_version(self.pypi_name)
+            odoo_serie = get_current_version(serie_only=True)
+            self.pypi_name = pypi.odoo_name_to_pkg_name(name, odoo_serie=odoo_serie)
+        self.latest_version = pypi.get_last_pypi_version(self.pypi_name, odoo=odoo)
         self._req = None
 
     @property

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "pre-commit",
     "psycopg2-binary>=2.7.6",
     "gitpython",
+    "packaging",
     "pyyaml>6.0.0",
     "ruamel.yaml",
     "kaptan",

--- a/tests/test_addon_add.py
+++ b/tests/test_addon_add.py
@@ -8,42 +8,48 @@ from .common import fake_project_root, mock_pypi_version_cache
 
 def test_add_new():
     addon_name = "edi_oca"
-    mock_pypi_version_cache(f"odoo-addon-{addon_name}", "1.9.0")
+    mock_pypi_version_cache(f"odoo13-addon-{addon_name}", "13.0.1.9.0")
+    mock_pypi_version_cache(f"odoo14-addon-{addon_name}", "14.0.1.9.0")
+    mock_pypi_version_cache(f"odoo-addon-{addon_name}", "15.0.1.9.0")
     with fake_project_root() as runner:
         result = runner.invoke(addon.add, addon_name)
         with open("./requirements.txt") as fd:
-            assert "odoo-addon-edi_oca == 1.9.0" in fd.read()
+            assert "odoo14-addon-edi_oca == 14.0.1.9.0" in fd.read()
         assert result.exit_code == 0
 
 
 def test_add_new_with_version():
     addon_name = "edi_oca"
-    mock_pypi_version_cache(f"odoo-addon-{addon_name}", "1.9.0")
+    mock_pypi_version_cache(f"odoo13-addon-{addon_name}", "13.0.1.9.0")
+    mock_pypi_version_cache(f"odoo14-addon-{addon_name}", "14.0.1.9.0")
+    mock_pypi_version_cache(f"odoo-addon-{addon_name}", "15.0.1.9.0")
     with fake_project_root() as runner:
-        version = "1.8.0"
+        version = "14.0.1.8.0"
         result = runner.invoke(addon.add, [addon_name, f"--version={version}"])
         with open("./requirements.txt") as fd:
-            assert f"odoo-addon-edi_oca == {version}" in fd.read()
+            assert f"odoo14-addon-edi_oca == {version}" in fd.read()
         assert result.exit_code == 0
 
 
 def test_upgrade():
     addon_name = "edi_oca"
-    mock_pypi_version_cache(f"odoo-addon-{addon_name}", "2.0.0")
+    mock_pypi_version_cache(f"odoo14-addon-{addon_name}", "14.0.2.0.0")
     with fake_project_root() as runner:
         with open("./requirements.txt", "w") as fd:
-            fd.write("odoo-addon-edi_oca == 1.8.0")
+            fd.write("odoo14-addon-edi_oca == 14.0.1.8.0")
         result = runner.invoke(addon.add, [addon_name, "--upgrade"], input="y")
-        version = "2.0.0"
+        version = "14.0.2.0.0"
         with open("./requirements.txt") as fd:
-            assert f"odoo-addon-edi_oca == {version}" in fd.read()
+            assert f"odoo14-addon-edi_oca == {version}" in fd.read()
         assert result.exit_code == 0
 
 
 def test_add_new_with_pr():
     addon_name = "edi_oca"
-    mock_pypi_version_cache(f"odoo-addon-{addon_name}", "1.9.0")
-    with fake_project_root() as runner:
+    mock_pypi_version_cache(f"odoo-addon-{addon_name}", "16.0.1.9.0")
+    with fake_project_root(
+        manifest=dict(odoo_version="16.0"), proj_version="16.0.0.1.0"
+    ) as runner:
         pr = "https://github.com/OCA/edi-framework/pull/3"
         expected = "odoo-addon-edi_oca @ git+https://github.com/OCA/edi-framework@refs/pull/3/head#subdirectory=setup/edi_oca"
         result = runner.invoke(addon.add, [addon_name, f"-p {pr}"])
@@ -54,13 +60,15 @@ def test_add_new_with_pr():
 
 def test_replace_pr():
     addon_name = "edi_oca"
-    mock_pypi_version_cache(f"odoo-addon-{addon_name}", "2.0.0")
+    mock_pypi_version_cache(f"odoo-addon-{addon_name}", "16.0.2.0.0")
     old_req = "odoo-addon-edi_oca @ git+https://github.com/OCA/edi-framework@refs/pull/3/head#subdirectory=setup/edi_oca"
-    with fake_project_root() as runner:
+    with fake_project_root(
+        manifest=dict(odoo_version="16.0"), proj_version="16.0.0.1.0"
+    ) as runner:
         with open("./requirements.txt", "w") as fd:
             fd.write(old_req)
         result = runner.invoke(addon.add, [addon_name])
-        version = "2.0.0"
+        version = "16.0.2.0.0"
         with open("./requirements.txt") as fd:
             assert f"odoo-addon-edi_oca == {version}" in fd.read()
         assert result.exit_code == 0

--- a/tests/test_addon_add_pending.py
+++ b/tests/test_addon_add_pending.py
@@ -14,7 +14,9 @@ from .fixtures import clear_caches  # noqa
 def test_add_new_pending_no_addons():
     pr = "https://github.com/OCA/edi-framework/pull/1"
     repo_name = "edi-framework"
-    with fake_project_root(manifest=dict(odoo_version="16.0")) as runner:
+    with fake_project_root(
+        manifest=dict(odoo_version="16.0"), proj_version="16.0.0.1.0"
+    ) as runner:
         repo = Repo(repo_name, path_check=False)
         assert not repo.has_pending_merges()
         result = runner.invoke(
@@ -32,7 +34,9 @@ def test_add_new_pending_with_addon_editable():
     pr = "https://github.com/OCA/edi-framework/pull/1"
     repo_name = "edi-framework"
     addon_name = "edi_oca"
-    with fake_project_root(manifest=dict(odoo_version="16.0")) as runner:
+    with fake_project_root(
+        manifest=dict(odoo_version="16.0"), proj_version="16.0.0.1.0"
+    ) as runner:
         repo = Repo(repo_name, path_check=False)
         req_path = get_project_dev_req()
         assert not req_path.exists()
@@ -56,7 +60,9 @@ def test_add_new_pending_with_addon_not_editable():
     pr = "https://github.com/OCA/edi-framework/pull/1"
     repo_name = "edi-framework"
     addon_name = "edi_oca"
-    with fake_project_root(manifest=dict(odoo_version="16.0")) as runner:
+    with fake_project_root(
+        manifest=dict(odoo_version="16.0"), proj_version="16.0.0.1.0"
+    ) as runner:
         repo = Repo(repo_name, path_check=False)
         req_path = get_project_dev_req()
         assert not req_path.exists()

--- a/tests/test_utils_pkg.py
+++ b/tests/test_utils_pkg.py
@@ -10,19 +10,19 @@ from .common import fake_project_root, mock_pypi_version_cache
 
 def test_pkg_class():
     addon_name = "edi_oca"
-    mock_pypi_version_cache(f"odoo-addon-{addon_name}", "1.9.0")
+    mock_pypi_version_cache(f"odoo14-addon-{addon_name}", "14.0.1.9.0")
     with fake_project_root():
         pkg = pkg_utils.Package(addon_name)
         assert pkg.odoo
         assert pkg.name == addon_name
-        assert pkg.pypi_name == f"odoo-addon-{addon_name}"
-        assert pkg.latest_version == "1.9.0"
+        assert pkg.pypi_name == f"odoo14-addon-{addon_name}"
+        assert pkg.latest_version == "14.0.1.9.0"
         assert pkg.pinned_version is None
 
 
 def test_pkg_class_has_pending_merge():
     addon_name = "edi_oca"
-    mock_pypi_version_cache(f"odoo-addon-{addon_name}", "1.9.0")
+    mock_pypi_version_cache(f"odoo14-addon-{addon_name}", "14.0.1.9.0")
     with fake_project_root():
         pkg = pkg_utils.Package(addon_name)
         old_req = f"{pkg.pypi_name} @ git+https://github.com/OCA/repo@refs/pull/3/head#subdirectory=setup/{pkg.name}"
@@ -35,7 +35,7 @@ def test_pkg_class_has_pending_merge():
 
 def test_pkg_class_is_editable():
     addon_name = "edi_oca"
-    mock_pypi_version_cache(f"odoo-addon-{addon_name}", "1.9.0")
+    mock_pypi_version_cache(f"odoo14-addon-{addon_name}", "14.0.1.9.0")
     with fake_project_root():
         pkg = pkg_utils.Package(addon_name)
         old_req = f"-e path/to/module/setup/{addon_name}"

--- a/tests/test_utils_pypi.py
+++ b/tests/test_utils_pypi.py
@@ -5,6 +5,8 @@ import responses
 
 from odoo_tools.utils import pypi as pypi_utils
 
+from .common import fake_project_root
+
 # NOTE: run this test only locally as it makes a real call to pypi
 # def test_get_last_pypi_version_real():
 #     pkg_name = "odoo-addon-edi_oca"
@@ -14,17 +16,28 @@ from odoo_tools.utils import pypi as pypi_utils
 
 def test_get_last_pypi_version():
     pkg_name = "odoo-addon-edi-oca"
-    data = {"info": {"version": "15.0.1.6.0"}}
+    data = {
+        "info": {"version": "15.0.1.6.0"},
+        "releases": {
+            "15.0.1.0.0": [],
+            "15.0.1.2.0": [],
+            "15.0.1.6.0": [],
+            "16.0.1.0.0": [],
+        },
+    }
     with responses.RequestsMock() as rsps:
-        rsps.add(
-            responses.GET,
-            f"https://pypi.org/pypi/{pkg_name}/json",
-            json=data,
-            status=200,
-            content_type="application/json",
-        )
-        latest_version = pypi_utils.get_last_pypi_version(pkg_name)
-        assert latest_version == "15.0.1.6.0"
+        with fake_project_root(
+            manifest=dict(odoo_version="15.0"), proj_version="15.0.0.1.0"
+        ):
+            rsps.add(
+                responses.GET,
+                f"https://pypi.org/pypi/{pkg_name}/json",
+                json=data,
+                status=200,
+                content_type="application/json",
+            )
+            latest_version = pypi_utils.get_last_pypi_version(pkg_name)
+            assert latest_version == "15.0.1.6.0"
 
 
 def test_odoo_name_to_pkg_name():


### PR DESCRIPTION
Without the patch, adding or upgrading an odoo addon would always get
the latest version, which could result in adding an addon meant for odoo
17 on a project using odoo 15.
    
closes #31
closes #33

includes #35
