### PR TITLE
🐛 Let subprocess.run access venv binaries

### DIFF
--- a/odoo_tools/utils/os_exec.py
+++ b/odoo_tools/utils/os_exec.py
@@ -1,9 +1,31 @@
 # Copyright 2023 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 
+import os
 import shlex
 import shutil
 import subprocess
+import sys
+
+
+def get_venv():
+    """Return an environment that includes the virtualenv in the PATH
+
+    When running otools from a virtualenv, where dependencies console scripts
+    might not have been installed globally, we need make sure the PATH is set
+    correctly so that the executables are found.
+    """
+    # If PATH is not set, we're likely running the tests
+    if not os.environ.get("PATH"):
+        return os.environ
+    bin_path = os.path.dirname(sys.executable)
+    # If the bin_path is already there, perhaps this is a global install
+    if bin_path in os.environ["PATH"]:
+        return os.environ
+    # Return a copy of the environment, with the venv bin path prepended to PATH
+    env = os.environ.copy()
+    env["PATH"] = f"{bin_path}:{env['PATH']}"
+    return env
 
 
 def run(cmd, drop_trailing_spaces=True):
@@ -12,7 +34,7 @@ def run(cmd, drop_trailing_spaces=True):
     :param cmd: the command to execute
     :param drop_trailing_eol: remove trailing end-of-line chars or other wrapping spaces.
     """
-    res = subprocess.run(shlex.split(cmd), stdout=subprocess.PIPE)
+    res = subprocess.run(shlex.split(cmd), stdout=subprocess.PIPE, env=get_venv())
     output = res.stdout.decode()
     if drop_trailing_spaces:
         output = output.strip()


### PR DESCRIPTION
When installing this project in a venv (as it should be, ie: with `pipx`), the dependencies are not directly exposed in the PATH.

So, CLI dependencies like `bumpversion`, `invoke`, and others are not found when running `subprocess.run` in the code.

This commit fixes this by adding the venv binaries to the PATH. Since they're added at the beginning of the PATH, they will be found before any other system-wide binaries, which ensures the correct version is used.