### PR TITLE
✨ Support python 3.12 and bump some dependencies

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -12,8 +12,8 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: 3.9
-      - uses: pre-commit/action@v3.0.0
+      - uses: pre-commit/action@v3.0.1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,14 +4,19 @@ on: [pull_request, push]
 
 jobs:
   test:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version:
+          - "3.8"
+          - "3.9"
+          - "3.10"
+          - "3.11"
+          - "3.12"
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
     "Natural Language :: English",
 ]
 dependencies = [
-    "invoke==2.0.0",
+    "invoke==2.2.0",
     "requests==2.31.0",
     "git-aggregator>=4.0",
     "git-autoshare",
@@ -27,6 +27,7 @@ dependencies = [
     "psycopg2-binary>=2.7.6",
     "gitpython",
     "packaging",
+    "setuptools",
     "pyyaml>6.0.0",
     "ruamel.yaml",
     "kaptan==0.6.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,9 +37,7 @@ dependencies = [
     "towncrier",
     "importlib_resources; python_version < '3.9'",
     "bump2version",
-    # Include fix for parsing editable requirements
-    # https://github.com/madpah/requirements-parser/pull/85
-    "requirements-parser @ https://github.com/simahawk/requirements-parser/archive/refs/heads/fix-editable.tar.gz",
+    "requirements-parser>=0.8.0",
     ]
 requires-python = ">=3.8"
 dynamic = ["version"]


### PR DESCRIPTION
`invoke` is bumped to `2.2.0` to support python 3.12.

`setuptools` is added explicitly as a dependency to support python 3.12.

> Python 3.12 release notes https://docs.python.org/3/whatsnew/3.12.html
>
> https://github.com/python/cpython/issues/95299: Do not pre-install setuptools in virtual environments
> created with venv. This means that distutils, setuptools, pkg_resources, and
> easy_install will no longer available by default; to access these run pip
> install setuptools in the activated virtual environment.