### PR TITLE
[FIX] otools-project --venv option

### DIFF
--- a/odoo_tools/cli/project.py
+++ b/odoo_tools/cli/project.py
@@ -131,7 +131,7 @@ def init(**kw):
     help="the commit hash to use for Odoo Enterprise. If not provided the docker image will be introspected.",
 )
 @click.option(
-    "--venv",
+    "--venv/--no-venv",
     type=bool,
     default=False,
     help="setup a virtual environment usable to work without docker",
@@ -151,9 +151,12 @@ def checkout_local_odoo(
     docker-compose file to mount the checkouts inside the image), or to develop without Docker using the same version
     as the one used in the image.
 
-    To develop without Docker you can call `otools-project local-odoo --venv .venv`: this will setup or update a
-    virtual environment in the directory with the required tools installed to run Odoo locally (you will still need
-    docker to get the correct versions of the source code, unless you pass the hashes on the command line).
+    To develop without Docker you can call:
+    `otools-project checkout-local-odoo --venv --venv-path=.venv`
+
+    This will setup or update a virtual environment in the directory with the required tools installed to run Odoo
+    locally (you will still need docker to get the correct versions of the source code, unless you pass the hashes
+    on the command line).
     """
     config = load_config()
     if config.template_version == 1:

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -214,7 +214,7 @@ def test_local_odoo_venv(runner):
             },
             {
                 "args": lambda a: str(a[0]).endswith("pip")
-                and str(a[3]).endswith("odoo/src/requirements.txt"),
+                and str(a[3]).endswith(f"{odoo_src_path}/requirements.txt"),
             },
             {
                 "args": lambda a: str(a[0]).endswith("pip")


### PR DESCRIPTION
make the `--venv` option to `otools-project checkout-local-odoo` a real togglable option, fixing the error message saying it requires an argument.