### PR TITLE
[FIX] otools-project: EOL on generated files

### DIFF
--- a/odoo_tools/cli/project.py
+++ b/odoo_tools/cli/project.py
@@ -89,6 +89,8 @@ def bootstrap_files(opts):
                 # TODO: use better variable tmpl?
                 for k, v in var_getter(opts).items():
                     content = content.replace(f"${k}", v)
+                    # avoid errors from end-of-file-fixer in pre-commit
+                    content = content.rstrip("\n") + "\n"
                 with open(dest, "w") as dest_fd:
                     dest_fd.write(content)
         else:


### PR DESCRIPTION
Ensure that the files generated by otools-project init from one of the template have an EOL on the last line. This prevents pre-commit on the customer project from complaining about this in the end-of-line-fixer check.