### PR TITLE
BSRD-806: Get back the submodule task

### DIFF
--- a/odoo_tools/cli/submodule.py
+++ b/odoo_tools/cli/submodule.py
@@ -69,7 +69,7 @@ git_aggregator.main.setup_logger()
 
 
 class Repo:
-    """Handle repository/submodule homogenously."""
+    """Handle repository/submodule homogeneously."""
 
     def __init__(self, name_or_path, path_check=True):
         self.path = self.build_submodule_path(name_or_path)
@@ -135,7 +135,7 @@ class Repo:
     def repositories_from_pending_folder(cls, path=None):
         path = path or PENDING_MERGES_DIR
         repo_names = []
-        for root, dirs, files in os.walk(path):
+        for __, __, files in os.walk(path):
             repo_names = [
                 os.path.splitext(fname)[0] for fname in files if fname.endswith(".yml")
             ]


### PR DESCRIPTION
https://camptocamp.atlassian.net/browse/BSRD-806

> [!NOTE]
> Commits have been ported from odoo-template

**TODO:**

- [x] Extract `submodule.py` from odoo-template's tasks
- [ ] Refactor as click tool
- [ ] Write unit tests