### PR TITLE
[FIX] otools-submodule ls

### DIFF
--- a/odoo_tools/cli/submodule.py
+++ b/odoo_tools/cli/submodule.py
@@ -54,13 +54,14 @@ def ls(dockerfile=False):
         blacklist = {"odoo/src"}
         lines = (f"odoo/{line}" for line in submodules if line not in blacklist)
         lines = chain(
-            lines,
             [
                 "odoo/src/odoo/odoo/addons",
                 "odoo/src/odoo/addons",
-                "odoo/enterprise",
+                "odoo/src/enterprise",
                 "odoo/odoo/addons",
             ],
+            lines,
+            ["odoo/odoo/paid-modules"],
         )
         lines = ("/%s" % line for line in lines)
         template = 'ENV ADDONS_PATH="%s" \\\n'

--- a/tests/test_submodule.py
+++ b/tests/test_submodule.py
@@ -167,11 +167,12 @@ def test_ls_dockerfile(project):
     )
     assert result.exit_code == 0
     assert result.output.splitlines() == [
-        'ENV ADDONS_PATH="/odoo/odoo/external-src/account-closing, \\',
-        "/odoo/odoo/external-src/account-financial-reporting, \\",
-        "/odoo/src/odoo/odoo/addons, \\",
+        'ENV ADDONS_PATH="/odoo/src/odoo/odoo/addons, \\',
         "/odoo/src/odoo/addons, \\",
-        "/odoo/enterprise, \\",
-        '/odoo/odoo/addons" \\',
+        "/odoo/src/enterprise, \\",
+        "/odoo/odoo/addons, \\",
+        "/odoo/odoo/external-src/account-closing, \\",
+        "/odoo/odoo/external-src/account-financial-reporting, \\",
+        '/odoo/odoo/paid-modules" \\',
         "",
     ]


### PR DESCRIPTION
Fix the path to enterprise/ was wrong

Add paid addons

Change the order to get

1. odoo core and EE
2. local addons
3. 3rd party addons
4. paid addons