### PR TITLE
|IMP] otools-pending aggregate: push consolidated branch by default

### DIFF
--- a/odoo_tools/cli/pending.py
+++ b/odoo_tools/cli/pending.py
@@ -54,7 +54,7 @@ def show_pending(repo_paths=(), state=None, purge=None):
     "--push/--no-push",
     "push",
     is_flag=True,
-    default=False,
+    default=True,
     help="push the result of the aggregation to a remote branch",
 )
 def aggregate(repo_path, target_branch=None, push=None):


### PR DESCRIPTION
We'll forget this parameter quite often and CI won't be happy, set it back by default like with former `invoke submodule.merges` task.