### PR TITLE
[IMP] otools-release bump: print next steps when ending

### DIFF
--- a/odoo_tools/cli/release.py
+++ b/odoo_tools/cli/release.py
@@ -4,11 +4,23 @@
 import click
 
 from ..config import get_conf_key
+from ..utils.git import get_current_branch
 from ..utils.marabunta import MarabuntaFileHandler
 from ..utils.misc import get_ini_cfg_key
 from ..utils.os_exec import run
 from ..utils.path import build_path
 from ..utils.pending_merge import push_branches
+
+END_TIPS = [
+    "Please continue with the release by:",
+    " * Checking the diff",
+    " * Running:",
+    "\tgit add ... # pick the files",
+    '\tgit commit -m"Release {version}"',
+    "\tgit tag -a {version}  # optionally -s to sign the tag",
+    "\t# copy-paste the content of the release from HISTORY.rst in the annotation of the tag",
+    "\tgit push origin {branch} --tags",
+]
 
 
 def get_bumpversion_cfg_key(cfg_content, key):
@@ -79,6 +91,11 @@ def bump(rel_type, new_version=None, dry_run=False, commit=False):
     # TODO + run pip freeze and override requirements.txt
     # docker-compose build --build-arg DEV_MODE=1 odoo
     # doco --rm run odoo pip freeze > requirements.txt
+
+    branch = get_current_branch()
+    if branch and new_version:
+        end_tips = "\n".join(END_TIPS).format(branch=branch, version=new_version)
+        click.echo(end_tips)
 
 
 if __name__ == "__main__":

--- a/odoo_tools/utils/git.py
+++ b/odoo_tools/utils/git.py
@@ -144,3 +144,13 @@ def set_remote_url(repo_path, url, remote="origin", add=False):
 def checkout(branch_name, remote="origin"):
     subprocess.run(["git", "fetch", remote, branch_name])
     subprocess.run(["git", "checkout", f"{remote}/{branch_name}"])
+
+
+def get_current_branch():
+    try:
+        branch = subprocess.check_output(
+            ["git", "branch", "--show-current"], text=True
+        ).strip()
+    except subprocess.CalledProcessError:
+        branch = None
+    return branch


### PR DESCRIPTION
Output:
```
[...]
Running: towncrier build --yes --version=18.0.0.5.0
Updating marabunta migration file
Please continue with the release by:
 * Cleaning HISTORY.rst. Remove the empty sections, empty lines...
 * Check the diff then run:
	git add ... # pick the files
	git commit -m"Release 18.0.0.5.0"
	git tag -a 18.0.0.5.0  # optionally -s to sign the tag
	# copy-paste the content of the release from HISTORY.rst in the annotation of the tag
	git push origin 18.0-mig --tags
```