### PR TITLE
Stop using docker-compose

### DIFF
--- a/odoo_tools/cli/project.py
+++ b/odoo_tools/cli/project.py
@@ -202,7 +202,7 @@ def checkout_local_odoo(
             """
 Then run:
 
-docker-compose run --rm odoo pip install --user -e /odoo/src/odoo
+docker compose run --rm odoo pip install --user -e /odoo/src/odoo
 """
         )
 

--- a/odoo_tools/cli/release.py
+++ b/odoo_tools/cli/release.py
@@ -89,7 +89,7 @@ def bump(rel_type, new_version=None, dry_run=False, commit=False):
         push_branches(version=new_version)
 
     # TODO + run pip freeze and override requirements.txt
-    # docker-compose build --build-arg DEV_MODE=1 odoo
+    # docker compose build --build-arg DEV_MODE=1 odoo
     # doco --rm run odoo pip freeze > requirements.txt
 
     branch = get_current_branch()

--- a/odoo_tools/tasks/database.py
+++ b/odoo_tools/tasks/database.py
@@ -44,16 +44,16 @@ def ensure_db_container_up(ctx):
     :return: True if already up, False if it wasn't
     """
     try:
-        ctx.run("docker-compose port db 5432", hide=True)
+        ctx.run("docker compose port db 5432", hide=True)
         started = True
     except Exception:
-        ctx.run("docker-compose up -d db", hide=True)
+        ctx.run("docker compose up -d db", hide=True)
         running = False
         # Wait for the container to start
         count = 0
         while not running:
             try:
-                ctx.run("docker-compose port db 5432", hide=True)
+                ctx.run("docker compose port db 5432", hide=True)
                 running = True
             except Exception as e:
                 count += 1
@@ -66,12 +66,12 @@ def ensure_db_container_up(ctx):
     yield
     # Stop the container if it wasn't already up and running
     if not started:
-        ctx.run("docker-compose stop db", hide=True)
+        ctx.run("docker compose stop db", hide=True)
 
 
 def get_db_container_port(ctx):
     """Get and return DB container port"""
-    run_res = ctx.run("docker-compose port db 5432", hide=True)
+    run_res = ctx.run("docker compose port db 5432", hide=True)
     return str(int(run_res.stdout.split(":")[-1]))
 
 
@@ -303,10 +303,10 @@ def restore_dump(ctx, dump_path, db_name="", hide_traceback=True):
         # ie: polished_morning_3582-20181114-031713
         db_name = os.path.splitext(os.path.basename(dump_path))[0]
     # rely on PG error if database already exists
-    ctx.run(f"docker-compose run --rm odoo createdb -O odoo {db_name}")
+    ctx.run(f"docker compose run --rm odoo createdb -O odoo {db_name}")
     print("Restoring", dump_path, "on", db_name)
     ctx.run(
-        "docker-compose run --rm odoo pg_restore -O "
+        "docker compose run --rm odoo pg_restore -O "
         f"-d {db_name} < {expand_path(dump_path)}",
         hide=hide_traceback,
     )
@@ -315,7 +315,7 @@ def restore_dump(ctx, dump_path, db_name="", hide_traceback=True):
         # print shortcut to run this new db
         print("You can Odoo on this DB:")
         print(
-            f"docker-compose run --rm -e DB_NAME={db_name} "
+            f"docker compose run --rm -e DB_NAME={db_name} "
             "-p 8069:8069 odoo odoo --workers=0"
         )
 

--- a/odoo_tools/tasks/translate.py
+++ b/odoo_tools/tasks/translate.py
@@ -30,31 +30,26 @@ def generate(ctx, addon_path, update_po=True):
     container_po_path = os.path.join(container_path, "%s.po" % addon)
     user_id = ctx.run("id --user", hide="both").stdout.strip()
     cmd_init = (
-        "docker-compose run --rm  -e LOCAL_USER_ID=%(user)s "
+        f"docker compose run --rm -e LOCAL_USER_ID={user_id} "
         "-e DEMO=False -e MIGRATE=False odoo odoo "
         "--log-level=warn --workers=0 "
-        "--database %(dbname)s "
+        f"--database {dbname} "
         "--stop-after-init --without-demo=all "
-        "--init=%(addon)s"
-    ) % {"user": user_id, "dbname": dbname, "addon": addon}
+        f"--init={addon}"
+    )
     cmd_gen = (
-        "docker-compose run --rm  -e LOCAL_USER_ID=%(user)s "
+        f"docker compose run --rm -e LOCAL_USER_ID={user_id} "
         "-e DEMO=False -e MIGRATE=False odoo odoo "
         "--log-level=warn --workers=0 "
-        "--database %(dbname)s --i18n-export=%(path)s "
-        "--modules=%(addon)s --stop-after-init --without-demo=all "
-    ) % {
-        "user": user_id,
-        "path": container_po_path,
-        "dbname": dbname,
-        "addon": addon,
-    }
+        f"--database {dbname} --i18n-export={container_po_path} "
+        f"--modules={addon} --stop-after-init --without-demo=all"
+    )
     ctx.run(cmd_init)
     ctx.run(cmd_gen)
 
     ctx.run(
-        "docker-compose run --rm -e PGPASSWORD=odoo odoo "
-        "dropdb %s -U odoo -h db" % dbname
+        "docker compose run --rm -e PGPASSWORD=odoo odoo "
+        f"dropdb {dbname} -U odoo -h db"
     )
 
     # mv .po to .pot

--- a/odoo_tools/utils/misc.py
+++ b/odoo_tools/utils/misc.py
@@ -48,7 +48,7 @@ def get_ini_cfg_key(cfg_content, header, key):
 def get_docker_image_commit_hashes():
     """Retrieve the odoo core and odoo enterprise commit hashes used in the project image"""
     process = subprocess.run(
-        ["docker-compose", "run", "--rm", "odoo", "printenv"],
+        ["docker", "compose", "run", "--rm", "odoo", "printenv"],
         check=True,
         stdout=subprocess.PIPE,
         text=True,

--- a/tests/test_utils_misc.py
+++ b/tests/test_utils_misc.py
@@ -24,7 +24,7 @@ def test_get_docker_image_commit_hashes():
     mock_fn = mock_subprocess_run(
         [
             {
-                "args": ["docker-compose", "run", "--rm", "odoo", "printenv"],
+                "args": ["docker", "compose", "run", "--rm", "odoo", "printenv"],
                 "stdout": "Starting with UID : 1043\nRunning without demo data\nPATH=/bin,/usr/bin\nCORE_HASH=12345\nENTERPRISE_HASH=56789\n",
             }
         ]


### PR DESCRIPTION
New projects use `docker compose` instead of separate tool `docker-compose`.