### PR TITLE
[ADD] otools-ba: tools for business analysts

### DIFF
--- a/ROADMAP.rst
+++ b/ROADMAP.rst
@@ -1,0 +1,1 @@
+otools-ba run: force image pulling if the docker-compose file is more than 1w old (meaning there has been a new image built since the last use of the tool)

--- a/changes.d/70.1.feat.rst
+++ b/changes.d/70.1.feat.rst
@@ -1,0 +1,20 @@
+New tool otools-ba run <odooversion>
+
+This tool can be used to run a vanilla Odoo, through the new docker images.
+
+```
+$ otools-ba run --help
+Usage: otools-ba run [OPTIONS] [VERSION]
+
+  Run a standard odoo version locally, for a demo or
+
+Options:
+  --empty-db / --no-empty-db      force recreation of an empty database.
+                                  Otherwise a previously created database for
+                                  that version can be reused.
+  -p, --port INTEGER              The network port on which you will need to
+                                  connect to access odoo.
+  --force-image-pull / --no-force-image-pull
+                                  Force pulling updated image
+  --help                          Show this message and exit.
+```

--- a/changes.d/70.feat.rst
+++ b/changes.d/70.feat.rst
@@ -1,0 +1,5 @@
+new command otools-ba
+
+This command contains tools crafted to help functional people work, possibly
+not directly on a project, without having to bother with knowing tons of
+command line tools.

--- a/odoo_tools/cli/batools.py
+++ b/odoo_tools/cli/batools.py
@@ -1,0 +1,156 @@
+# Copyright 2023 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+
+
+import re
+import subprocess
+
+import click
+import jinja2
+
+from ..utils import ui
+from ..utils.misc import get_cache_path
+from ..utils.path import cd
+
+
+@click.group()
+def cli():
+    pass
+
+
+@cli.command(
+    help="Run a standard odoo version locally, for a customer demo or testing standard features."
+)
+@click.argument(
+    "version",
+    required=False,
+    default="18.0",
+    nargs=1,
+)
+@click.option(
+    "--empty-db/--no-empty-db",
+    default=True,
+    help="force recreation of an empty database. Otherwise a previously created database for that version can be reused.",
+)
+@click.option(
+    "-p",
+    "--port",
+    default=8080,
+    help="The network port on which you will need to connect to access odoo.",
+)
+@click.option(
+    "--force-image-pull/--no-force-image-pull",
+    default=False,
+    help="Force pulling updated image",
+)
+def run(empty_db, port, force_image_pull, version):
+    # we are storing the data and the logs in ~/.cache/otools/batools/localrun-<version>
+    # this enables keeping a cache of the databases through the docker composition name,
+    # for instance, and having the execution logs available for examination if something crashes.
+    run_dir = get_cache_path() / "batools" / f"localrun-{version}"
+    run_dir.mkdir(parents=True, exist_ok=True)
+    if not re.match(r"^\d\d.\d$", version):
+        ui.exit_msg("Version must be an odoo version (e.g. 17.0)")
+
+    jinja_env = jinja2.Environment(
+        loader=jinja2.PackageLoader("odoo_tools"),
+    )
+    template = jinja_env.get_template("localrun_docker_compose.yml.tmpl")
+    dkr_compose = template.render(odoo_version=version)
+    with cd(run_dir):
+        with open("docker-compose.yml", "w") as fobj:
+            fobj.write(dkr_compose)
+        with open("docker_logs.txt", "wb") as logfile:
+            ui.echo(
+                f"Pulling docker image (this can be long). Logs are in {run_dir/'docker_logs.txt'}"
+            )
+            if force_image_pull:
+                # todo: force image pulling if the docker-compose file is more than 1w old
+                # (meaning there has been a new image built since the last use of the tool)
+                policy = "always"
+            else:
+                policy = "missing"
+            subprocess.run(
+                [
+                    "docker",
+                    "compose",
+                    "pull",
+                    "--quiet",
+                    "--policy",
+                    policy,
+                    "--include-deps",
+                    "odoo",
+                ],
+                stdout=logfile,
+            )
+        with open("odoo_logs.txt", "w", buffering=1) as logfile:
+            ui.echo("Initializing the database")
+            subprocess.run(
+                ["docker", "compose", "down"]
+            )  # avoid error with another Odoo running in the same port
+            if empty_db:
+                ui.echo("Remove previous database")
+                subprocess.run(
+                    [
+                        "docker",
+                        "compose",
+                        "run",
+                        "--rm",
+                        "-e",
+                        "MIGRATE=false",
+                        "odoo",
+                        "sh -c dropdb odoodb",
+                    ],
+                    stdout=logfile,
+                    stderr=logfile,
+                    text=True,
+                )
+            subprocess.run(
+                [
+                    "docker",
+                    "compose",
+                    "run",
+                    "--rm",
+                    "-e",
+                    "MIGRATE=false",
+                    "odoo",
+                    "odoo",
+                    "--stop-after-init",
+                ],
+                stdout=logfile,
+                stderr=logfile,
+                text=True,
+            )
+            ui.echo("Starting Odoo")
+            pipe = subprocess.Popen(
+                [
+                    "docker",
+                    "compose",
+                    "run",
+                    "--rm",
+                    "-q",
+                    "-e",
+                    "MIGRATE=false",
+                    "--interactive=false",
+                    "-p",
+                    f"{port}:8069",
+                    "odoo",
+                    "odoo",
+                ],
+                stderr=subprocess.PIPE,
+                stdout=logfile,
+                bufsize=1,
+                text=True,
+            )
+            for line in pipe.stderr:
+                logfile.write(line)
+                if "Registry loaded" in line:
+                    ui.echo(f"You can connect to http://localhost:{port}")
+
+            subprocess.run(
+                ["docker", "compose", "down"]
+            )  # avoid error with another Odoo running in the same port
+
+
+if __name__ == "__main__":
+    cli()

--- a/odoo_tools/templates/localrun_docker_compose.yml.tmpl
+++ b/odoo_tools/templates/localrun_docker_compose.yml.tmpl
@@ -1,0 +1,83 @@
+services:
+  odoo:
+    image: ghcr.io/camptocamp/odoo-enterprise:{{odoo_version}}-latest
+    #image: ghcr.io/camptocamp/odoo-enterprise:18.0-latest
+    depends_on:
+      - db
+      - kwkhtmltopdf
+    tty: true
+    stdin_open: true
+    ports:
+      - 8069
+      - 8072
+    volumes:
+      # if you want to debug odoo using a local copy, edit docker-composer.override.yml
+      # to mount the checked out source code
+      - "data-odoo:/odoo/data/odoo"
+      - "data-odoo-db-cache:/.cachedb"
+      - "data-odoo-pytest-cache:/odoo/.cache"
+    environment:
+      DB_USER: odoo
+      DB_PASSWORD: odoo
+      DB_NAME: odoodb
+      ADMIN_PASSWD: mijaebohb8Thae1g
+      RUNNING_ENV: dev
+      PYTHONDONTWRITEBYTECODE: 1
+      # Enable if you use oca/connector:
+      # ODOO_QUEUE_JOB_CHANNELS: root:4
+      MARABUNTA_MODE: sample  # could be 'full' for the db with all the data
+      MARABUNTA_ALLOW_SERIE: 'True'  # should not be set in production
+      SERVER_WIDE_MODULES: web
+      ODOO_REPORT_URL: http://odoo:8069
+      KWKHTMLTOPDF_SERVER_URL: http://kwkhtmltopdf:8080
+      WORKERS: 0
+
+  kwkhtmltopdf:
+    {%- if odoo_version|int <= 15.0 %}
+    image: ghcr.io/camptocamp/kwkhtmltopdf:0.12.5-1.2.2
+    {%- else %}
+    image: ghcr.io/camptocamp/kwkhtmltopdf:2.0.2
+    {%- endif %}
+    ports:
+      - 8080
+
+  db:
+    image: ghcr.io/camptocamp/postgres:14-postgis-3
+    command: -c shared_buffers=256MB -c maintenance_work_mem=256MB -c wal_buffers=8MB -c effective_cache_size=1024MB -c shared_preload_libraries=pg_stat_statements
+    ports:
+      - 5432
+    environment:
+      POSTGRES_INITDB_ARGS: --encoding=UTF-8 --lc-collate=C --lc-ctype=C
+      POSTGRES_USER: odoo
+      POSTGRES_PASSWORD: odoo
+    volumes:
+      - "data-db:/var/lib/postgresql/data"
+
+  nginx:
+    image: camptocamp/odoo-nginx:1.8.3
+    depends_on:
+      - odoo
+    ports:
+      - 80:80
+
+  mailhog:
+    image: mailhog/mailhog
+    ports:
+      - 8025:8025
+
+  mailcatcher:
+    image: estelora/mailcatcher-imap
+    environment:
+      MAILCATCHER_USERNAME: mailcatcher
+      MAILCATCHER_PASSWORD: mailcatcher
+    ports:
+      - 1080:80
+      - 993:993
+      - "1025:25"
+
+volumes:
+  data-odoo:
+  data-db:
+  data-odoo-db-cache:
+  data-odoo-pytest-cache:
+  odoo-source:

--- a/odoo_tools/utils/misc.py
+++ b/odoo_tools/utils/misc.py
@@ -2,6 +2,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 
 import configparser
+import pathlib
 import shutil
 import subprocess
 from importlib.resources import files
@@ -15,6 +16,10 @@ def get_file_path(filepath):
 
 def get_template_path(filepath):
     return get_file_path("templates/" + filepath)
+
+
+def get_cache_path():
+    return pathlib.Path.home() / ".cache" / "otools"
 
 
 def copy_file(src_path, dest_path):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [
     "towncrier",
     "bump2version",
     "requirements-parser>=0.8.0",
+    "Jinja2",
     ]
 requires-python = ">=3.9"
 dynamic = ["version"]
@@ -57,6 +58,8 @@ otools-submodule = "odoo_tools.cli.submodule:cli"
 otools-release = "odoo_tools.cli.release:cli"
 otools-pending = "odoo_tools.cli.pending:cli"
 otools-conversion = "odoo_tools.conversion.convert_new_img:main"
+otools-ba = "odoo_tools.cli.batools:cli"
+
 
 [project.optional-dependencies]
 test = [


### PR DESCRIPTION
These tools are not necessarily directly useful for projects, but they can be used to abstract things out, and provide direct shortcuts for BAs who may not be super well versed in the internals of git, docker, etc.

First command provided: ``otools-ba run <odoo-version>``

This will download a "new" docker image for that version and start it. Some options are proviced to set a port, preserve a possibly preexisting database, and pull an updated version of the image.