### PR TITLE
[ADD] checkout-local-odoo use git autoshare

### DIFF
--- a/ROADMAP.rst
+++ b/ROADMAP.rst
@@ -1,1 +1,0 @@
-use git-autoshare when getting odoo core and src

--- a/changes.d/71.1.fix.rst
+++ b/changes.d/71.1.fix.rst
@@ -1,0 +1,1 @@
+crash of otools-project checkout-local-odoo on second run of the command

--- a/changes.d/71.feat.rst
+++ b/changes.d/71.feat.rst
@@ -1,0 +1,1 @@
+Use git autoshare in command otools-project checkout-local-odoo

--- a/odoo_tools/utils/git.py
+++ b/odoo_tools/utils/git.py
@@ -38,20 +38,25 @@ def get_odoo_enterprise(hash, dest="src/enterprise", org="odoo", branch=None):
 
 
 def _clone_or_fetch_repo(org, repo, branch, dest):
-    # TODO: use git-autoshare clone
+    repo_url = f"git@github.com:{org}/{repo}"
+    __, autoshare_repo = find_autoshare_repository([repo_url])
     if os.path.isdir(os.path.join(dest, ".git")):
         ui.echo(f"Fetching {org}/{repo} {branch}")
         subprocess.run(["git", "-C", dest, "fetch", "--quiet", "--all"], check=True)
     else:
+        if autoshare_repo:
+            command = "autoshare-clone"
+        else:
+            command = "clone"
         ui.echo(f"Cloning {org}/{repo} on branch {branch}, be patient")
         subprocess.run(
             [
                 "git",
-                "clone",
+                command,
                 "--quiet",
                 "--branch",
                 branch,
-                f"git@github.com:{org}/{repo}",
+                repo_url,
                 dest,
             ],
             check=True,


### PR DESCRIPTION
use git-autoshare when running otools-project checkout-local-odoo.

fixes: #71