### PR TITLE
[FIX] broken tests

### DIFF
--- a/changes.d/+1fe603f8.fix.rst
+++ b/changes.d/+1fe603f8.fix.rst
@@ -1,0 +1,1 @@
+Fix tests broken by change introduced in click 8.2.1

--- a/changes.d/70.fix.rst
+++ b/changes.d/70.fix.rst
@@ -1,0 +1,1 @@
+otools-project: fix local checkout automated tests

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -50,6 +50,10 @@ def test_init(project, version):
         expected = get_fixture(f"expected.proj.v{version}.cfg")
         compare_line_by_line(content, expected)
     assert result.exit_code == 0
+    autoshare_cache_dir = Path("./.cache/git-autoshare").absolute()
+    autoshare_config_dir = Path("./.config/git-autoshare").absolute()
+    os.environ["GIT_AUTOSHARE_CACHE_DIR"] = str(autoshare_cache_dir)
+    os.environ["GIT_AUTOSHARE_CONFIG_DIR"] = str(autoshare_config_dir)
 
 
 @pytest.mark.project_setup(proj_tmpl_ver=1)

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -86,7 +86,7 @@ def test_bump_changelog():
             with open(path, "w") as fd:
                 fd.write(change)
         result = runner.invoke(
-            release.bump, ["--type", "minor"], catch_exceptions=False
+            release.bump, ["--type", "minor"], catch_exceptions=False, input="n"
         )
         date = datetime.date.today().strftime("%Y-%m-%d")
         expected = "\n".join(
@@ -105,7 +105,7 @@ def test_bump_changelog():
             "Running: bumpversion minor",
             "Running: towncrier build --yes --version=14.0.0.2.0",
             "Updating marabunta migration file",
-            "Push local branches? [y/N]: ",
+            "Push local branches? [y/N]: n",
         ]
         assert result.exit_code == 0
 
@@ -117,7 +117,7 @@ def test_bump_update_marabunta_file():
         # run init to get all files ready (eg: bumpversion)
         runner.invoke(init, catch_exceptions=False)
         result = runner.invoke(
-            release.bump, ["--type", "minor"], catch_exceptions=False
+            release.bump, ["--type", "minor"], catch_exceptions=False, input="\n"
         )
         with get_conf_key("marabunta_mig_file_rel_path").open() as fd:
             content = fd.read()


### PR DESCRIPTION
Tests went red after tagging 0.10.0, this was caused by the release of click 8.2.1 fixing https://github.com/pallets/click/issues/2787 

Also, the tests would not run locally if git autoshare was correctly setup -> fixing this by mocking the git autoshare config. 