### PR TITLE
[FIX]: show_closed_prs allow to launch the command to display

### DIFF
--- a/changes.d/show_closed_prs.fix
+++ b/changes.d/show_closed_prs.fix
@@ -1,0 +1,1 @@
+otools-tasks: fix show_closed_prs to allow it to show the PRs without cleaning

--- a/odoo_tools/tasks/submodule.py
+++ b/odoo_tools/tasks/submodule.py
@@ -430,12 +430,13 @@ def show_closed_prs(ctx, submodule_path=None, purge_closed=False, purge_merged=F
     Pass `-s path/to/submodule` to check specific ones.
     """
     all_repos_prs = show_prs(ctx, submodule_path=submodule_path, state="closed")
-    return _purge_closed_prs(
-        ctx,
-        all_repos_prs,
-        purge_closed=purge_closed,
-        purge_merged=purge_merged,
-    )
+    if any([purge_closed, purge_merged]):
+        return _purge_closed_prs(
+            ctx,
+            all_repos_prs,
+            purge_closed=purge_closed,
+            purge_merged=purge_merged,
+        )
 
 
 def _purge_closed_prs(ctx, all_repos_prs, purge_merged=False, purge_closed=False):


### PR DESCRIPTION
without doing any cleaning action.

I would like to be able to asset the PRs state without launching a cleaning.
It is currently not possible as at the end of the method you enter into `_purge_closed_prs` that needs one of the parameters to be set `[purge_closed, purge_merged]`