### PR TITLE
[FIX] browser being launched more than once

### DIFF
--- a/changes.d/90.fix.rst
+++ b/changes.d/90.fix.rst
@@ -1,0 +1,1 @@
+fix detection of instance readiness and avoid launching the browser multiple times

--- a/odoo_tools/cli/batools.py
+++ b/odoo_tools/cli/batools.py
@@ -123,6 +123,9 @@ def run(empty_db, port, force_image_pull, version):
                     if "Registry loaded" in line or "Modules loaded" in line:
                         ui.echo(f"You can connect to http://localhost:{port}")
                         subprocess.Popen(["xdg-open", f"http://localhost:{port}"])
+                        break
+                for line in pipe.stderr:
+                    logfile.write(line)
             except KeyboardInterrupt:
                 ui.echo("Exiting...")
             finally:


### PR DESCRIPTION
If a worker restart, possibly because of memory consumption, the the line which triggers launching the browser will be redisplayed in the logs, and the tool will restart the browser.

We fix this by stopping the search for the "Registry loaded" string after we find it for the first time.

fixes: https://github.com/camptocamp/odoo-project-tools/issues/90