### PR TITLE
[FIX] crash on otools-pr test

### DIFF
--- a/changes.d/95.fix.rst
+++ b/changes.d/95.fix.rst
@@ -1,0 +1,1 @@
+fix crash on otools-pr test when the version reported by docker compose is not made only of integers (#95)

--- a/odoo_tools/utils/docker_compose.py
+++ b/odoo_tools/utils/docker_compose.py
@@ -12,7 +12,7 @@ from . import os_exec
 
 def get_version():
     version = os_exec.run("docker compose version --short")
-    return [int(x) for x in version.split(".")]
+    return [int(x) for x in version.split(".") if x.isdigit()]
 
 
 def up(override=None):

--- a/tests/test_utils_docker_compose.py
+++ b/tests/test_utils_docker_compose.py
@@ -128,7 +128,7 @@ def test_run_version_2_33():
         [
             {
                 "args": ["docker", "compose", "version", "--short"],
-                "stdout": b"2.33.1",
+                "stdout": b"2.33.1-ubuntuLTS",
             }
         ]
     )


### PR DESCRIPTION
if docker compose version returns something which is not made entirely of strings, we get a crash. Fix it by only checking the first 2 digits of the version.

fixes: #95