### PR TITLE
[REM] marabunta dependency

### DIFF
--- a/changes.d/remove-marabunta-dep.build
+++ b/changes.d/remove-marabunta-dep.build
@@ -1,0 +1,1 @@
+Remove marabunta dependency

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,6 @@ dependencies = [
     "git-autoshare",
     "passlib",
     "clipboard",
-    "marabunta",
     "pre-commit",
     "psycopg2-binary>=2.7.6",
     "gitpython",


### PR DESCRIPTION
It was used in the previous release.bump task, solely for the MarabuntaVersion class.
But that was dropped with the use of `bumpversion`

This is a heavy dependency due to its psycopg (not -binary) dependency. So better not to include it unless needed