### PR TITLE
otools-release bump: two empty lines to separate versions

### DIFF
--- a/odoo_tools/templates/.towncrier-template.tmpl.rst
+++ b/odoo_tools/templates/.towncrier-template.tmpl.rst
@@ -22,3 +22,5 @@ No significant changes.
 
 {% endif %}
 {% endfor %}
+
+{# END -- 2 blank lines to separate versions #}


### PR DESCRIPTION
Slightly better layout for generated `./HISTORY.rst`