### PR TITLE
[FIX] Fix circular import in config and implement cached config

### DIFF
--- a/odoo_tools/cli/project.py
+++ b/odoo_tools/cli/project.py
@@ -5,8 +5,8 @@ import os
 
 import click
 
-from ..config import PROJ_CFG_FILE, load_config
 from ..utils import git, ui
+from ..utils.config import PROJ_CFG_FILE, config
 from ..utils.misc import (
     SmartDict,
     copy_file,
@@ -32,7 +32,6 @@ def get_proj_tmpl_ver():
 def get_bumpversion_vars(opts):
     version = opts.version or get_current_version()
     odoo_major, odoo_minor, __ = version.split(".", 2)
-    config = load_config()
     res = {
         "rel_path_local_addons": config.local_src_rel_path.as_posix(),
         "rel_path_version_file": config.version_file_rel_path.as_posix(),
@@ -176,7 +175,6 @@ def checkout_local_odoo(
     locally (you will still need docker to get the correct versions of the source code, unless you pass the hashes
     on the command line).
     """
-    config = load_config()
     if config.template_version == 1:
         ui.exit_msg("This command is not support on this project version;")
     version = get_current_version(serie_only=True)

--- a/odoo_tools/cli/release.py
+++ b/odoo_tools/cli/release.py
@@ -1,9 +1,11 @@
 # Copyright 2023 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 
+from pathlib import Path
+
 import click
 
-from ..config import get_conf_key
+from ..utils.config import config
 from ..utils.git import get_current_branch
 from ..utils.marabunta import MarabuntaFileHandler
 from ..utils.misc import get_ini_cfg_key
@@ -42,7 +44,7 @@ def make_towncrier_cmd(version):
 
 
 def update_marabunta_file(version):
-    marabunta_file = build_path(get_conf_key("marabunta_mig_file_rel_path"))
+    marabunta_file = build_path(config.marabunta_mig_file_rel_path)
     handler = MarabuntaFileHandler(marabunta_file)
     handler.update(version)
 
@@ -76,8 +78,7 @@ def bump(rel_type, new_version=None, dry_run=False, commit=False):
         new_version = get_bumpversion_cfg_key(res, "new_version").strip()
         click.echo(f"New version: {new_version}")
         return
-    with get_conf_key("version_file_rel_path").open() as fd:
-        new_version = fd.read().strip()
+    new_version = Path(config.version_file_rel_path).read_text().strip()
 
     cmd = make_towncrier_cmd(new_version)
     click.echo(f"Running: {cmd}")

--- a/odoo_tools/conversion/convert_new_img.py
+++ b/odoo_tools/conversion/convert_new_img.py
@@ -27,7 +27,7 @@ except ImportError:
     )
     odoorpc = None
 
-from ..config import get_conf_key
+from ..config import config
 from ..utils.path import root_path
 from ..utils.proj import get_current_version
 from ..utils.pypi import odoo_name_to_pkg_name
@@ -94,7 +94,7 @@ docker build .
 
 
 def main(args=None):
-    if get_conf_key("template_version") == 2:
+    if config.template_version == 2:
         print("Project already migrated")
         return sys.exit(0)
     if args is None:

--- a/odoo_tools/utils/__init__.py
+++ b/odoo_tools/utils/__init__.py
@@ -1,5 +1,6 @@
 from . import (
     click,
+    config,
     db,
     docker_compose,
     gh,
@@ -19,6 +20,7 @@ from . import (
 
 __all__ = [
     "click",
+    "config",
     "db",
     "docker_compose",
     "gh",

--- a/odoo_tools/utils/pending_merge.py
+++ b/odoo_tools/utils/pending_merge.py
@@ -11,10 +11,10 @@ import git_aggregator.repo
 import requests
 from ruamel.yaml.comments import CommentedMap, CommentedSeq
 
-from ..config import get_conf_key
 from ..exceptions import PathNotFound
 from ..utils.misc import SmartDict, get_docker_image_commit_hashes
 from . import gh, git, ui
+from .config import config
 from .os_exec import run
 from .path import build_path, cd
 from .proj import get_current_version, get_project_manifest_key
@@ -35,11 +35,11 @@ class Repo:
     """Handle checked out repositories and their pending merges."""
 
     def __init__(self, name_or_path, path_check=True):
-        self.template_version = get_conf_key("template_version") or 1
-        self.company_git_remote = get_conf_key("company_git_remote")
-        self.odoo_src_rel_path = get_conf_key("odoo_src_rel_path")
-        self.ext_src_rel_path = get_conf_key("ext_src_rel_path")
-        self.pending_merge_rel_path = get_conf_key("pending_merge_rel_path")
+        self.template_version = config.template_version or 1
+        self.company_git_remote = config.company_git_remote
+        self.odoo_src_rel_path = config.odoo_src_rel_path
+        self.ext_src_rel_path = config.ext_src_rel_path
+        self.pending_merge_rel_path = config.pending_merge_rel_path
         self.pending_merge_abs_path = build_path(self.pending_merge_rel_path)
         self.path = self.make_repo_path(name_or_path)
         self.abs_path = build_path(self.path)
@@ -89,7 +89,7 @@ class Repo:
 
     @classmethod
     def repositories_from_pending_folder(cls, path=None):
-        pending_merge_abs_path = build_path(get_conf_key("pending_merge_rel_path"))
+        pending_merge_abs_path = build_path(config.pending_merge_rel_path)
         path = Path(path or pending_merge_abs_path)
         return [cls(pth.stem) for pth in path.rglob("*.yml")]
 
@@ -715,18 +715,18 @@ def push_branches(version=None, force=False):
 
     # look through all of the files inside PENDING_MERGES_DIR, push everything
     impacted_repos = []
-    company_git_remote = get_conf_key("company_git_remote")
+    company_git_remote = config.company_git_remote
     for repo in Repo.repositories_from_pending_folder():
         if not repo.has_pending_merges():
             continue
-        config = repo.merges_config()
+        merges_config = repo.merges_config()
         impacted_repos.append(repo.path)
         ui.echo(f"Pushing {repo.path}")
         with cd(repo.abs_path):
             try:
                 run(f"git config remote.{company_git_remote}.url")
             except Exception:  # TODO
-                remote_url = config["remotes"][company_git_remote]
+                remote_url = merges_config["remotes"][company_git_remote]
                 run(f"git remote add {company_git_remote} {remote_url}")
             run(f"git push -f -v {company_git_remote} HEAD:refs/heads/{branch_name}")
     if impacted_repos:

--- a/odoo_tools/utils/proj.py
+++ b/odoo_tools/utils/proj.py
@@ -5,8 +5,8 @@ import subprocess
 import venv
 from functools import cache
 
-from ..config import get_conf_key
 from . import ui
+from .config import config
 from .misc import get_template_path
 from .path import build_path, get_root_marker, root_path
 from .yaml import yaml_load
@@ -23,7 +23,7 @@ def get_project_manifest_key(key):
 
 
 def get_current_version(serie_only=False):
-    ver_file = build_path(get_conf_key("version_file_rel_path"))
+    ver_file = build_path(config.version_file_rel_path)
     ver = ver_file.read_text().strip()
     if serie_only:
         ver = ver.split(".")[0]
@@ -39,7 +39,7 @@ def setup_venv(venv_dir, odoo_src_path=None):
         venv.create(venv_dir, with_pip=True)
     pip = venv_dir / "bin/pip"
     if odoo_src_path is None:
-        odoo_src_path = build_path(get_conf_key("odoo_src_rel_path"))
+        odoo_src_path = build_path(config.odoo_src_rel_path)
 
     if not (venv_dir / "bin/odoo").is_file():
         subprocess.run(

--- a/odoo_tools/utils/req.py
+++ b/odoo_tools/utils/req.py
@@ -7,8 +7,8 @@ from pathlib import Path
 
 import requirements
 
-from ..config import get_conf_key
 from . import ui
+from .config import config
 from .gh import parse_github_url
 from .path import root_path
 from .pypi import pkg_name_to_odoo_name
@@ -66,7 +66,7 @@ def modname_to_installation_subdirectory(mod_name: str, use_wool: bool):
 def make_requirement_line_for_proj_fork(
     pkg_name, repo_name, branch, upstream=None, use_wool=False
 ):
-    upstream = upstream or get_conf_key("company_git_remote")
+    upstream = upstream or config.company_git_remote
     mod_name = pkg_name_to_odoo_name(pkg_name)
     parts = {
         "upstream": upstream,
@@ -85,7 +85,7 @@ def make_requirement_line_for_editable(
     if pr:
         parts = parse_github_url(pr)
         repo_name = parts["repo_name"]
-    dev_src = dev_src or get_conf_key("ext_src_rel_path")
+    dev_src = dev_src or config.ext_src_rel_path
     mod_name = pkg_name_to_odoo_name(pkg_name)
     subdirectory = modname_to_installation_subdirectory(mod_name, use_wool)
     return f"-e {dev_src}/{repo_name}/{subdirectory}"

--- a/tests/common.py
+++ b/tests/common.py
@@ -6,8 +6,8 @@ from pathlib import PosixPath
 
 from click.testing import CliRunner
 
-from odoo_tools.config import get_conf_key
 from odoo_tools.utils import pending_merge as pm_utils
+from odoo_tools.utils.config import config
 from odoo_tools.utils.path import get_root_marker
 from odoo_tools.utils.yaml import update_yml_file
 
@@ -87,6 +87,7 @@ def make_fake_project_root(
         for k, v in proj_cfg_data.items():
             content.append(f"{k} = {v}")
         fd.write("\n".join(content))
+    config._reload()
     data = FAKE_MANIFEST_DATA.copy()
     data.update(manifest or {})
     # create empty file
@@ -97,7 +98,7 @@ def make_fake_project_root(
     with open(req_file, "w") as fd:
         fd.write("")
     # Mock proj version file
-    ver_file = get_conf_key("version_file_rel_path")
+    ver_file = config.version_file_rel_path
 
     os.makedirs(ver_file.parent.as_posix(), exist_ok=True)
     with ver_file.open("w") as fd:
@@ -117,7 +118,7 @@ def fake_marabunta_file(source_file_path=None):
     if not os.path.exists("odoo"):
         os.mkdir("odoo")
     with source_file_path.open() as fd_source:
-        with get_conf_key("marabunta_mig_file_rel_path").open("w") as fd_dest:
+        with config.marabunta_mig_file_rel_path.open("w") as fd_dest:
             fd_dest.write(fd_source.read())
 
 

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -8,7 +8,7 @@ from unittest import mock
 import pytest
 
 from odoo_tools.cli.project import checkout_local_odoo, init
-from odoo_tools.config import load_config
+from odoo_tools.utils.config import config
 from odoo_tools.utils.path import build_path
 
 from .common import compare_line_by_line, get_fixture, mock_subprocess_run
@@ -30,6 +30,7 @@ from .common import compare_line_by_line, get_fixture, mock_subprocess_run
 def test_init(project, version):
     # Drop mocked cfg (necessary to make fake_project_root work before)
     os.remove(".proj.cfg")
+    config._reload()
     with mock.patch.dict(os.environ, {"PROJ_TMPL_VER": str(version)}, clear=True):
         result = project.invoke(init, catch_exceptions=False)
     paths = (
@@ -94,7 +95,6 @@ def test_init_custom_version(project):
 @pytest.mark.usefixtures("project")
 @pytest.mark.project_setup(proj_tmpl_ver=2, proj_version="16.0.1.1.0")
 def test_checkout_local_odoo(runner):
-    config = load_config()
     odoo_src_path = build_path(config.odoo_src_rel_path)
     mock_fn = mock_subprocess_run(
         [
@@ -159,7 +159,6 @@ def test_checkout_local_odoo(runner):
 @pytest.mark.usefixtures("project")
 @pytest.mark.project_setup(proj_tmpl_ver=2, proj_version="16.0.1.1.0")
 def test_local_odoo_venv(runner):
-    config = load_config()
     odoo_src_path = build_path(config.odoo_src_rel_path)
     config_file = build_path("odoo.cfg")
 

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -6,7 +6,7 @@ from unittest import mock
 
 from odoo_tools.cli import release
 from odoo_tools.cli.project import init
-from odoo_tools.config import get_conf_key
+from odoo_tools.utils.config import config
 
 from .common import (
     compare_line_by_line,
@@ -33,7 +33,7 @@ def test_bump():
     with fake_project_root(
         proj_version="14.0.0.1.0", mock_marabunta_file=True
     ) as runner:
-        ver_file = get_conf_key("version_file_rel_path")
+        ver_file = config.version_file_rel_path
         with ver_file.open() as fd:
             assert fd.read() == "14.0.0.1.0"
         # run init to get all files ready (eg: bumpversion)
@@ -131,11 +131,10 @@ def test_bump_update_marabunta_file():
         result = runner.invoke(
             release.bump, ["--type", "minor"], catch_exceptions=False, input="\n"
         )
-        with get_conf_key("marabunta_mig_file_rel_path").open() as fd:
-            content = fd.read()
-            # TODO: improve these checks
-            assert "14.0.0.2.0" in content
-            assert "click-odoo-update" in content
+        content = config.marabunta_mig_file_rel_path.read_text()
+        # TODO: improve these checks
+        assert "14.0.0.2.0" in content
+        assert "click-odoo-update" in content
         assert result.output.splitlines() == [
             "Running: bumpversion minor",
             "Running: towncrier build --yes --version=14.0.0.2.0",

--- a/tests/test_utils_pending_merge.py
+++ b/tests/test_utils_pending_merge.py
@@ -7,9 +7,9 @@ from unittest import mock
 
 import pytest
 
-from odoo_tools.config import get_conf_key
 from odoo_tools.exceptions import Exit, PathNotFound
 from odoo_tools.utils import pending_merge as pm_utils
+from odoo_tools.utils.config import config
 
 from .common import fake_project_root, mock_pending_merge_repo_paths
 
@@ -25,8 +25,8 @@ def compare_dict(a, b, keys=None):
 
 def test_repo_base():
     with fake_project_root():
-        ext_rel_path = get_conf_key("ext_src_rel_path")
-        pending_merge_rel_path = get_conf_key("pending_merge_rel_path")
+        ext_rel_path = config.ext_src_rel_path
+        pending_merge_rel_path = config.pending_merge_rel_path
         cwd = PosixPath(os.getcwd())
         repo = Repo("edi", path_check=False)
         expected = {

--- a/tests/test_utils_proj.py
+++ b/tests/test_utils_proj.py
@@ -3,8 +3,8 @@
 
 from unittest import mock
 
-from odoo_tools.config import get_conf_key
 from odoo_tools.utils import proj as proj_utils
+from odoo_tools.utils.config import config
 from odoo_tools.utils.path import build_path
 
 from .common import compare_line_by_line, fake_project_root, mock_subprocess_run
@@ -58,7 +58,7 @@ def test_get_project_manifest_key():
 
 def test_generate_odoo_config_file():
     with fake_project_root(proj_tmpl_ver="2", proj_version="16.0.1.1.0"):
-        odoo_src_path = build_path(get_conf_key("odoo_src_rel_path"))
+        odoo_src_path = build_path(config.odoo_src_rel_path)
         odoo_enterprise_path = str(odoo_src_path / "../enterprise")
         venv_dir = build_path(".venv")
         odoo_exec = venv_dir / "bin/odoo"
@@ -91,7 +91,5 @@ def test_generate_odoo_config_file():
             proj_utils.generate_odoo_config_file(
                 venv_dir, odoo_src_path, odoo_enterprise_path, database_name="testdb"
             )
-        with open(config_file) as fobj:
-            config = fobj.read()
         expected = "db_name=testdb\n\nrunning_env=dev\n"
-        compare_line_by_line(config, expected)
+        compare_line_by_line(config_file.read_text(), expected)

--- a/tests/test_utils_req.py
+++ b/tests/test_utils_req.py
@@ -3,8 +3,8 @@
 
 from click.testing import CliRunner
 
-from odoo_tools.config import get_conf_key
 from odoo_tools.utils import req as req_utils
+from odoo_tools.utils.config import config
 
 from .common import fake_project_root, get_fixture_path
 
@@ -69,7 +69,7 @@ def test_make_requirement_line_for_pr_editable():
         mod_name = "edi_record_metadata_oca"
         pkg_name = f"odoo14-addon-{mod_name}"
         pr = "https://github.com/OCA/edi-framework/pull/3"
-        path = get_conf_key("ext_src_rel_path")
+        path = config.ext_src_rel_path
         expected = f"-e {path}/edi-framework/setup/edi_record_metadata_oca"
         assert make(pkg_name, pr) == expected
 
@@ -110,7 +110,7 @@ def test_add_requirement_pr_editable():
         req_utils.add_requirement(
             pkg_name, pr=pr, req_filepath=req_path, editable=True, use_wool=False
         )
-        path = get_conf_key("ext_src_rel_path")
+        path = config.ext_src_rel_path
         expected = f"-e {path}/edi-framework/setup/{mod_name}"
         with open(req_path) as fd:
             assert fd.read() == expected


### PR DESCRIPTION
```
> otools-project --help

ImportError: cannot import name 'get_conf_key' from partially initialized module 'odoo_tools.config' (most likely due to a circular import)
```

That's a regression caused by this: https://github.com/camptocamp/odoo-project-tools/blob/99346be1a0207194f3ba37e5cf725303cce47a14/odoo_tools/utils/__init__.py

Related to: https://camptocamp.atlassian.net/browse/BSRD-844
