### PR TITLE
[FIX] otools-migrate-db: avoid extra DB removal and restore with `--restart-c2c` flag set

### DIFF
--- a/odoo_tools/cli/migrate_db.py
+++ b/odoo_tools/cli/migrate_db.py
@@ -434,7 +434,7 @@ def migrate_c2c_external(ctx):
     db_name = ctx.obj["db_name"]
     log_file = ctx.obj["store_path"].joinpath(f"{db_name}_c2c_external.log")
     try:
-        if not _db_exists(db_name) or ctx.params["restart_c2c"]:
+        if not _db_exists(db_name) or ctx.params["restart_c2c_external"]:
             db_previous = ctx.obj["db_c2c_core"]
             _run_docker_compose_cmd(f"run --rm odoo dropdb --if-exists {db_name}")
             _run_docker_compose_cmd(
@@ -464,7 +464,7 @@ def migrate_c2c_local(ctx):
     db_name = ctx.obj["db_name"]
     log_file = ctx.obj["store_path"].joinpath(f"{db_name}_c2c_local.log")
     try:
-        if not _db_exists(db_name) or ctx.params["restart_c2c"]:
+        if not _db_exists(db_name) or ctx.params["restart_c2c_local"]:
             db_previous = ctx.obj["db_c2c_external"]
             _run_docker_compose_cmd(f"run --rm odoo dropdb --if-exists {db_name}")
             _run_docker_compose_cmd(
@@ -494,7 +494,7 @@ def migrate_c2c_cleanup(ctx):
     db_name = ctx.obj["db_name"]
     log_file = ctx.obj["store_path"].joinpath(f"{db_name}_c2c_cleanup.log")
     try:
-        if not _db_exists(db_name) or ctx.params["restart_c2c"]:
+        if not _db_exists(db_name) or ctx.params["restart_c2c_cleanup"]:
             db_previous = ctx.obj["db_c2c_local"]
             _run_docker_compose_cmd(f"run --rm odoo dropdb --if-exists {db_name}")
             _run_docker_compose_cmd(


### PR DESCRIPTION
When the parameter `--restart-c2c` is set, we wish to remove current working DB and restore it in `core` step (with the DB coming from the last step, so `odoo_migrated` here).

Then for next steps, we don't want anymore to drop & restore the DB because the `--restart-c2c` flag is set. Working on current DB is OK. The only case where DB has to be dropped is then the flag `--restart-c2c-{step}` is set.

With this change we could spare time when running dev migration builds on top of Odoo S.A. migrated DB (dev iterations).
E.g on Cosanum we could spare ~1h of build time.