### PR TITLE
otools-project checkout-local-odoo: use docker compose command

### DIFF
--- a/changes.d/+34f80283.fix.rst
+++ b/changes.d/+34f80283.fix.rst
@@ -1,0 +1,1 @@
+otools-project checkout-local-odoo: use docker compose command

--- a/tests/test_utils_misc.py
+++ b/tests/test_utils_misc.py
@@ -31,19 +31,21 @@ def test_get_docker_image_commit_hashes():
     mock_fn = mock_subprocess_run(
         [
             {
+                "args": ["docker", "compose", "version", "--short"],
+                "stdout": b"2.36.2",
+            },
+            {
                 "args": [
                     "docker",
+                    "compose",
                     "run",
-                    "--quiet",
                     "--rm",
-                    "--pull",
-                    "always",
-                    "--entrypoint",
+                    "--quiet",
+                    "odoo",
                     "printenv",
-                    "ghcr.io/camptocamp/odoo-enterprise:15.0-latest",
                 ],
-                "stdout": "Starting with UID : 1043\nRunning without demo data\nPATH=/bin,/usr/bin\nCORE_HASH=12345\nENTERPRISE_HASH=56789\n",
-            }
+                "stdout": b"Starting with UID : 1043\nRunning without demo data\nPATH=/bin,/usr/bin\nCORE_HASH=12345\nENTERPRISE_HASH=56789\n",
+            },
         ]
     )
     with patch("subprocess.run", mock_fn):


### PR DESCRIPTION
Without this, in my MacOs setup it was failing with:

```
docker: no matching manifest for linux/arm64/v8 in the manifest list entries
```

That's natural, because I explicitly ask for the linux/amd64 image in my docker-compose.override.yml file, but the previous code was not using docker compose.

So, this fix makes the command use docker compose and inspect the image directly