### PR TITLE
[REM] marabunta: click-odoo-update hook

### DIFF
--- a/odoo_tools/utils/marabunta.py
+++ b/odoo_tools/utils/marabunta.py
@@ -10,7 +10,7 @@ class MarabuntaFileHandler:
     def load(self):
         return yaml.yaml_load(self.path_obj.open())
 
-    def update(self, version, run_click_hook="post"):
+    def update(self, version):
         data = self.load()
         versions = data["migration"]["versions"]
         version_item = [x for x in versions if x["version"] == version]
@@ -19,16 +19,7 @@ class MarabuntaFileHandler:
         else:
             version_item = {"version": version}
             versions.append(version_item)
-        if not version_item.get("operations"):
-            version_item["operations"] = {}
-        operations = version_item["operations"]
-        cmd = self._make_click_odoo_update_cmd()
-        if cmd not in operations.get(run_click_hook, []):
-            operations.setdefault(run_click_hook, []).append(cmd)
         yaml.update_yml_file(self.path_obj, data)
-
-    def _make_click_odoo_update_cmd(self):
-        return "click-odoo-update"
 
     def get_migration_file_modules(self):
         """Read the migration.yml and get module list."""

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -134,7 +134,6 @@ def test_bump_update_marabunta_file():
         content = config.marabunta_mig_file_rel_path.read_text()
         # TODO: improve these checks
         assert "14.0.0.2.0" in content
-        assert "click-odoo-update" in content
         assert result.output.splitlines() == [
             "Running: bumpversion minor",
             "Running: towncrier build --yes --version=14.0.0.2.0",


### PR DESCRIPTION
`click-odoo-contrib` is not installed in our images, so we end up removing click-odoo-update from marabunta file every time we do a release.

Moreoever, I doubt marabunta is the right place for it.
IMHO I would reduce our dependency on marabunta, so I would rather execute elsewhere, like in the image start-entrypoint.

@simahawk are you already using it in one of your projects? I will start experimenting with ssv