### PR TITLE
Restore git push instructions from invoke tasks

### DIFF
--- a/odoo_tools/cli/release.py
+++ b/odoo_tools/cli/release.py
@@ -20,7 +20,7 @@ END_TIPS = [
     '\tgit commit -m "Release {version}"',
     "\tgit tag -a {version}  # optionally -s to sign the tag",
     "\t# copy-paste the content of the release from HISTORY.rst in the annotation of the tag",
-    "\tgit push origin {branch} --tags",
+    "\tgit push --tags && git push origin {branch}",
 ]
 
 


### PR DESCRIPTION
I guess this was wrongly changed when moving the invoke tasks into this repository as the new syntax was pushing the branch before the tag, whereas we must always prefer to push the tag before the branch.
The reason for this is we want the build for the tag to start before the build of the branch, so that we do not have to wait on two builds to be able to deploy the docker image built from the tag.