### PR TITLE
[FIX] otools-pending remove: crash when removing last pending merge

### DIFF
--- a/changes.d/+3e4c4274.fix.rst
+++ b/changes.d/+3e4c4274.fix.rst
@@ -1,0 +1,1 @@
+otools-pending remove: crash when removing last pending merge

--- a/odoo_tools/utils/gh.py
+++ b/odoo_tools/utils/gh.py
@@ -59,7 +59,8 @@ def get_current_rebase_branch():
         # directories, in a file named "head-name"
         rebase_dir = run(f"git rev-parse --git-path {rebase_file}")
         rebase_dir = Path(rebase_dir)
-        if rebase_dir.exists():
+        rebase_head_name = rebase_dir / "head-name"
+        if rebase_head_name.exists():
             head_name = (rebase_dir / "head-name").read_text().strip()
             current_branch = head_name.replace("refs/heads/", "")
             break

--- a/odoo_tools/utils/pending_merge.py
+++ b/odoo_tools/utils/pending_merge.py
@@ -679,15 +679,9 @@ def remove_pending(entity_url, aggregate=True):
 
     # check if that file is useless since it has an empty `merges` section
     # if it does - drop it instead of writing a new file version
-    # only the upstream branch is present in `merges`
-    # first item is `- oca 11.0` or similar
-    config = repo.merges_config()
-    pending_merges_present = len(config["merges"]) > 1
-    patches = len(config.get("shell_command_after", {}))
-
-    if not pending_merges_present and not patches:
-        repo.abs_merges_path.unlink()
-    if aggregate:
+    if not repo.has_any_pr_left():
+        repo._handle_empty_merges_file(delete_file=True)
+    elif aggregate:
         aggregator = repo.get_aggregator()
         aggregator.aggregate()
     return repo

--- a/tests/test_utils_pending_merge.py
+++ b/tests/test_utils_pending_merge.py
@@ -260,6 +260,34 @@ def test_remove_pending_pr():
     assert merges == expected
 
 
+@pytest.mark.usefixtures("all_template_versions")
+@pytest.mark.project_setup(
+    manifest=dict(odoo_version="14.0"), proj_version="14.0.0.1.0"
+)
+def test_remove_pending_last_pr():
+    """Test removing the last pending PR deletes the merges file."""
+    name = "edi"
+    # Template with only one pending PR (besides the base branch)
+    tmpl = """
+../{ext_src_rel_path}/{repo_name}:
+    remotes:
+        camptocamp: git@github.com:camptocamp/{repo_name}.git
+        {org_name}: git@github.com:{org_name}/{repo_name}.git
+    target: camptocamp merge-branch-{pid}-master
+    merges:
+    - {org_name} 14.0
+    - {org_name} refs/pull/774/head
+"""
+    mock_pending_merge_repo_paths(name, tmpl=tmpl)
+    repo = Repo(name, path_check=False)
+    merges = repo.merges_config().get("merges", [])
+    assert merges == ["OCA 14.0", "OCA refs/pull/774/head"]
+    # Remove the only pending PR via the top-level function
+    with mock.patch.object(Repo, "_handle_empty_merges_file") as mock_handle:
+        pm_utils.remove_pending("https://github.com/OCA/edi/pull/774")
+    mock_handle.assert_called_once()
+
+
 # TODO: test all cases
 def __test_add_pending_commit_from_scratch():
     name = "edi"


### PR DESCRIPTION
When the last pending PR was removed, the merges file was deleted but the aggregator still tried to read it, causing a ConfigException.

```
git_aggregator.exception.ConfigException: Unable to find configuration file: /[...]/pending-merges.d/server-env.yml
```

Skip aggregation when the file has been removed (no merges left).