### PR TITLE
[FIX] otools-submodule upgrade

### DIFF
--- a/odoo_tools/cli/submodule.py
+++ b/odoo_tools/cli/submodule.py
@@ -146,7 +146,7 @@ def push(submodule_path, target_branch=None):
     ui.echo("Done.")
 
 
-@click.command()
+@cli.command()
 @click.argument("submodule_path", required=False, default=None)
 @click.option(
     "--force-branch", default=None, help="Force checkout of a specific branch"


### PR DESCRIPTION
I introduced a typo during the PR rebase
which made the command unavailable