### PR TITLE
[REF] release: migrate from bump2version to bump-my-version

### DIFF
--- a/odoo_tools/cli/release.py
+++ b/odoo_tools/cli/release.py
@@ -7,10 +7,10 @@ from ..exceptions import ProjectConfigException
 from ..utils.config import config
 from ..utils.git import get_current_branch
 from ..utils.marabunta import MarabuntaFileHandler
-from ..utils.misc import get_ini_cfg_key
 from ..utils.os_exec import run
 from ..utils.path import build_path
 from ..utils.pending_merge import push_branches
+from ..utils.proj import get_current_version
 
 END_TIPS = [
     "Please continue with the release by:",
@@ -24,18 +24,17 @@ END_TIPS = [
 ]
 
 
-def get_bumpversion_cfg_key(cfg_content, key):
-    return get_ini_cfg_key(cfg_content, "bumpversion", key)
-
-
 def make_bumpversion_cmd(rel_type, new_version=None, dry_run=False):
-    cmd = ["bumpversion", "--list"]
-    if new_version:
-        cmd.append(f"--new-version {new_version}")
     if dry_run:
-        cmd.append("--dry-run")
+        cmd = ["bump-my-version", "show", "new_version", "--increment", rel_type]
+        if new_version:
+            cmd.extend(["--new-version", new_version])
+        return cmd
+    cmd = ["bump-my-version", "bump"]
+    if new_version:
+        cmd.extend(["--new-version", new_version])
     cmd.append(rel_type)
-    return " ".join(cmd)
+    return cmd
 
 
 def make_towncrier_cmd(version):
@@ -76,11 +75,13 @@ def bump(rel_type, new_version=None, dry_run=False, commit=False):
     """Prepare a new release"""
     cmd = make_bumpversion_cmd(rel_type, new_version=new_version, dry_run=dry_run)
     res = run(cmd, check=True, verbose=True)
-    new_version = get_bumpversion_cfg_key(res, "new_version").strip()
 
     if dry_run:
+        new_version = res.strip()
         click.echo(f"New version: {new_version}")
         return
+
+    new_version = get_current_version()
 
     cmd = make_towncrier_cmd(new_version)
     run(cmd, check=True, verbose=True)

--- a/odoo_tools/cli/release.py
+++ b/odoo_tools/cli/release.py
@@ -93,10 +93,6 @@ def bump(rel_type, new_version=None, dry_run=False, commit=False):
     if click.confirm("Push local branches?"):
         push_branches(version=new_version)
 
-    # TODO + run pip freeze and override requirements.txt
-    # docker compose build --build-arg DEV_MODE=1 odoo
-    # doco --rm run odoo pip freeze > requirements.txt
-
     branch = get_current_branch()
     if branch and new_version:
         end_tips = "\n".join(END_TIPS).format(branch=branch, version=new_version)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
     "click>=8.1",
     "rich",
     "towncrier",
-    "bump2version",
+    "bump-my-version",
     "requirements-parser>=0.8.0",
     "Jinja2",
     ]

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -16,11 +16,19 @@ from .common import compare_line_by_line, mock_pending_merge_repo_paths
 
 def test_make_bumpversion_cmd():
     cmd = release.make_bumpversion_cmd("patch")
-    assert cmd == "bumpversion --list patch"
+    assert cmd == ["bump-my-version", "bump", "patch"]
     cmd = release.make_bumpversion_cmd("patch", new_version="14.0.1.2.0")
-    assert cmd == "bumpversion --list --new-version 14.0.1.2.0 patch"
+    assert cmd == ["bump-my-version", "bump", "--new-version", "14.0.1.2.0", "patch"]
     cmd = release.make_bumpversion_cmd("patch", new_version="14.0.1.2.0", dry_run=True)
-    assert cmd == "bumpversion --list --new-version 14.0.1.2.0 --dry-run patch"
+    assert cmd == [
+        "bump-my-version",
+        "show",
+        "new_version",
+        "--increment",
+        "patch",
+        "--new-version",
+        "14.0.1.2.0",
+    ]
 
 
 def test_make_towncrier_cmd():
@@ -50,7 +58,7 @@ def test_bump(project):
         release.bump, ["--type", "major", "--dry-run"], catch_exceptions=False
     )
     assert result.output.splitlines() == [
-        "Running: bumpversion --list --dry-run major",
+        "Running: bump-my-version show new_version --increment major",
         "New version: 15.0.1.0.0",
     ]
     assert ver_file.read_text() == "15.0.0.0.1"
@@ -91,7 +99,7 @@ def test_bump_changelog(project):
         hist_part_1 + new_part + hist_part_2,
     )
     assert result.output.splitlines() == [
-        "Running: bumpversion --list minor",
+        "Running: bump-my-version bump minor",
         "Running: towncrier build --yes --version=14.0.0.2.0",
         "Updating marabunta migration file",
         "Push local branches? [y/N]: n",
@@ -109,7 +117,7 @@ def test_bump_update_marabunta_file(project):
     content = config.marabunta_mig_file_rel_path.read_text()
     assert "14.0.0.2.0" in content
     assert result.output.splitlines() == [
-        "Running: bumpversion --list minor",
+        "Running: bump-my-version bump minor",
         "Running: towncrier build --yes --version=14.0.0.2.0",
         "Updating marabunta migration file",
         "Push local branches? [y/N]: ",
@@ -129,7 +137,7 @@ def test_bump_update_without_marabunta_file(project):
         release.bump, ["--type", "minor"], catch_exceptions=False, input="\n"
     )
     assert result.output.splitlines() == [
-        "Running: bumpversion --list minor",
+        "Running: bump-my-version bump minor",
         "Running: towncrier build --yes --version=14.0.0.2.0",
         "Push local branches? [y/N]: ",
     ]
@@ -151,7 +159,7 @@ def test_bump_without_version_file(project):
         release.bump, ["--type", "minor"], catch_exceptions=False, input="\n"
     )
     assert result.output.splitlines() == [
-        "Running: bumpversion --list minor",
+        "Running: bump-my-version bump minor",
         "Running: towncrier build --yes --version=18.0.0.1.0",
         "Updating marabunta migration file",
         "Push local branches? [y/N]: ",
@@ -162,7 +170,7 @@ def test_bump_without_version_file(project):
         release.bump, ["--type", "minor"], catch_exceptions=False, input="\n"
     )
     assert result.output.splitlines() == [
-        "Running: bumpversion --list minor",
+        "Running: bump-my-version bump minor",
         "Running: towncrier build --yes --version=18.0.0.2.0",
         "Updating marabunta migration file",
         "Push local branches? [y/N]: ",
@@ -187,7 +195,7 @@ def test_bump_bundle_addon_manifest_version(project):
         release.bump, ["--type", "minor"], catch_exceptions=False, input="\n"
     )
     assert result.output.splitlines() == [
-        "Running: bumpversion --list minor",
+        "Running: bump-my-version bump minor",
         "Running: towncrier build --yes --version=18.0.1.3.0",
         "Updating marabunta migration file",
         "Push local branches? [y/N]: ",
@@ -216,7 +224,7 @@ def test_bump_bundle_addon_manifest_version_without_version_file(project):
         release.bump, ["--type", "minor"], catch_exceptions=False, input="\n"
     )
     assert result.output.splitlines() == [
-        "Running: bumpversion --list minor",
+        "Running: bump-my-version bump minor",
         "Running: towncrier build --yes --version=18.0.1.3.0",
         "Updating marabunta migration file",
         "Push local branches? [y/N]: ",
@@ -234,7 +242,7 @@ def test_bump_push_no_repo(project):
         release.bump, ["--type", "minor"], catch_exceptions=False, input="y"
     )
     assert result.output.splitlines() == [
-        "Running: bumpversion --list minor",
+        "Running: bump-my-version bump minor",
         "Running: towncrier build --yes --version=14.0.0.2.0",
         "Updating marabunta migration file",
         "Push local branches? [y/N]: y",
@@ -259,7 +267,7 @@ def test_bump_push_repo_with_pending_merge(project):
             release.bump, ["--type", "minor"], catch_exceptions=False, input="y"
         )
     assert result.output.splitlines() == [
-        "Running: bumpversion --list minor",
+        "Running: bump-my-version bump minor",
         "Running: towncrier build --yes --version=14.0.0.2.0",
         "Updating marabunta migration file",
         "Push local branches? [y/N]: y",

--- a/uv.lock
+++ b/uv.lock
@@ -12,6 +12,20 @@ wheels = [
 ]
 
 [[package]]
+name = "anyio"
+version = "4.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353, upload-time = "2026-03-24T12:59:08.246Z" },
+]
+
+[[package]]
 name = "appdirs"
 version = "1.4.4"
 source = { registry = "https://pypi.org/simple" }
@@ -55,12 +69,32 @@ wheels = [
 ]
 
 [[package]]
-name = "bump2version"
-version = "1.0.1"
+name = "bracex"
+version = "2.6"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/29/2a/688aca6eeebfe8941235be53f4da780c6edee05dbbea5d7abaa3aab6fad2/bump2version-1.0.1.tar.gz", hash = "sha256:762cb2bfad61f4ec8e2bdf452c7c267416f8c70dd9ecb1653fd0bbb01fa936e6", size = 36236, upload-time = "2020-10-07T18:38:40.119Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/63/9a/fec38644694abfaaeca2798b58e276a8e61de49e2e37494ace423395febc/bracex-2.6.tar.gz", hash = "sha256:98f1347cd77e22ee8d967a30ad4e310b233f7754dbf31ff3fceb76145ba47dc7", size = 26642, upload-time = "2025-06-22T19:12:31.254Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1d/e3/fa60c47d7c344533142eb3af0b73234ef8ea3fb2da742ab976b947e717df/bump2version-1.0.1-py2.py3-none-any.whl", hash = "sha256:37f927ea17cde7ae2d7baf832f8e80ce3777624554a653006c9144f8017fe410", size = 22030, upload-time = "2020-10-07T18:38:38.148Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/2a/9186535ce58db529927f6cf5990a849aa9e052eea3e2cfefe20b9e1802da/bracex-2.6-py3-none-any.whl", hash = "sha256:0b0049264e7340b3ec782b5cb99beb325f36c3782a32e36e876452fd49a09952", size = 11508, upload-time = "2025-06-22T19:12:29.781Z" },
+]
+
+[[package]]
+name = "bump-my-version"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "httpx" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+    { name = "questionary" },
+    { name = "rich" },
+    { name = "rich-click" },
+    { name = "tomlkit" },
+    { name = "wcmatch" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3d/61/07b90027091a4192b4a0290dc3da1aeea6b9e7b6b4c0f7fd30dab36070c1/bump_my_version-1.3.0.tar.gz", hash = "sha256:5780137a8d93378af3839798fcba01c7e6cb28dcc5aa5a7ab4d8507787f1995c", size = 1142429, upload-time = "2026-03-22T13:27:34.923Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/36/01/b168791bfbfb0322ef6d38d236f6f17a02e41fb7753e23e4cdb0f19ac969/bump_my_version-1.3.0-py3-none-any.whl", hash = "sha256:3cdaa54588d2443a29303b77e7539417187952c3d22f87bfdd32c0fe6af2f570", size = 64878, upload-time = "2026-03-22T13:27:33.006Z" },
 ]
 
 [[package]]
@@ -416,6 +450,43 @@ wheels = [
 ]
 
 [[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
 name = "identify"
 version = "2.6.16"
 source = { registry = "https://pypi.org/simple" }
@@ -585,7 +656,7 @@ wheels = [
 name = "odoo-tools"
 source = { editable = "." }
 dependencies = [
-    { name = "bump2version" },
+    { name = "bump-my-version" },
     { name = "click" },
     { name = "clipboard" },
     { name = "cookiecutter" },
@@ -619,7 +690,7 @@ test = [
 
 [package.metadata]
 requires-dist = [
-    { name = "bump2version" },
+    { name = "bump-my-version" },
     { name = "click", specifier = ">=8.1" },
     { name = "clipboard" },
     { name = "cookiecutter" },
@@ -698,6 +769,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/40/f1/6d86a29246dfd2e9b6237f0b5823717f60cad94d47ddc26afa916d21f525/pre_commit-4.5.1.tar.gz", hash = "sha256:eb545fcff725875197837263e977ea257a402056661f09dae08e4b149b030a61", size = 198232, upload-time = "2025-12-16T21:14:33.552Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5d/19/fd3ef348460c80af7bb4669ea7926651d1f95c23ff2df18b9d24bab4f3fa/pre_commit-4.5.1-py2.py3-none-any.whl", hash = "sha256:3b3afd891e97337708c1674210f8eba659b52a38ea5f822ff142d10786221f77", size = 226437, upload-time = "2025-12-16T21:14:32.409Z" },
+]
+
+[[package]]
+name = "prompt-toolkit"
+version = "3.0.52"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wcwidth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a1/96/06e01a7b38dce6fe1db213e061a4602dd6032a8a97ef6c1a862537732421/prompt_toolkit-3.0.52.tar.gz", hash = "sha256:28cde192929c8e7321de85de1ddbe736f1375148b02f2e17edd840042b1be855", size = 434198, upload-time = "2025-08-27T15:24:02.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/03/0d3ce49e2505ae70cf43bc5bb3033955d2fc9f932163e84dc0779cc47f48/prompt_toolkit-3.0.52-py3-none-any.whl", hash = "sha256:9aac639a3bbd33284347de5ad8d68ecc044b91a762dc39b7c21095fcd6a19955", size = 391431, upload-time = "2025-08-27T15:23:59.498Z" },
 ]
 
 [[package]]
@@ -897,6 +980,20 @@ wheels = [
 ]
 
 [[package]]
+name = "pydantic-settings"
+version = "2.13.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/52/6d/fffca34caecc4a3f97bda81b2098da5e8ab7efc9a66e819074a11955d87e/pydantic_settings-2.13.1.tar.gz", hash = "sha256:b4c11847b15237fb0171e1462bf540e294affb9b86db4d9aa5c01730bdbe4025", size = 223826, upload-time = "2026-02-19T13:45:08.055Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/00/4b/ccc026168948fec4f7555b9164c724cf4125eac006e176541483d2c959be/pydantic_settings-2.13.1-py3-none-any.whl", hash = "sha256:d56fd801823dbeae7f0975e1f8c8e25c258eb75d278ea7abb5d9cebb01b56237", size = 58929, upload-time = "2026-02-19T13:45:06.034Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
@@ -969,6 +1066,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
+name = "python-dotenv"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
 ]
 
 [[package]]
@@ -1048,6 +1154,18 @@ wheels = [
 ]
 
 [[package]]
+name = "questionary"
+version = "2.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "prompt-toolkit" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f6/45/eafb0bba0f9988f6a2520f9ca2df2c82ddfa8d67c95d6625452e97b204a5/questionary-2.1.1.tar.gz", hash = "sha256:3d7e980292bb0107abaa79c68dd3eee3c561b83a0f89ae482860b181c8bd412d", size = 25845, upload-time = "2025-08-28T19:00:20.851Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3c/26/1062c7ec1b053db9e499b4d2d5bc231743201b74051c973dadeac80a8f43/questionary-2.1.1-py3-none-any.whl", hash = "sha256:a51af13f345f1cdea62347589fbb6df3b290306ab8930713bfae4d475a7d4a59", size = 36753, upload-time = "2025-08-28T19:00:19.56Z" },
+]
+
+[[package]]
 name = "requests"
 version = "2.33.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1099,6 +1217,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/fb/d2/8920e102050a0de7bfabeb4c4614a49248cf8d5d7a8d01885fbb24dc767a/rich-14.2.0.tar.gz", hash = "sha256:73ff50c7c0c1c77c8243079283f4edb376f0f6442433aecb8ce7e6d0b92d1fe4", size = 219990, upload-time = "2025-10-09T14:16:53.064Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/25/7a/b0178788f8dc6cafce37a212c99565fa1fe7872c70c6c9c1e1a372d9d88f/rich-14.2.0-py3-none-any.whl", hash = "sha256:76bc51fe2e57d2b1be1f96c524b890b816e334ab4c1e45888799bfaab0021edd", size = 243393, upload-time = "2025-10-09T14:16:51.245Z" },
+]
+
+[[package]]
+name = "rich-click"
+version = "1.9.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "rich" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/04/27/091e140ea834272188e63f8dd6faac1f5c687582b687197b3e0ec3c78ebf/rich_click-1.9.7.tar.gz", hash = "sha256:022997c1e30731995bdbc8ec2f82819340d42543237f033a003c7b1f843fc5dc", size = 74838, upload-time = "2026-01-31T04:29:27.707Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/e5/d708d262b600a352abe01c2ae360d8ff75b0af819b78e9af293191d928e6/rich_click-1.9.7-py3-none-any.whl", hash = "sha256:2f99120fca78f536e07b114d3b60333bc4bb2a0969053b1250869bcdc1b5351b", size = 71491, upload-time = "2026-01-31T04:29:26.777Z" },
 ]
 
 [[package]]
@@ -1201,6 +1334,15 @@ wheels = [
 ]
 
 [[package]]
+name = "tomlkit"
+version = "0.14.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/af/14b24e41977adb296d6bd1fb59402cf7d60ce364f90c890bd2ec65c43b5a/tomlkit-0.14.0.tar.gz", hash = "sha256:cf00efca415dbd57575befb1f6634c4f42d2d87dbba376128adb42c121b87064", size = 187167, upload-time = "2026-01-13T01:14:53.304Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b5/11/87d6d29fb5d237229d67973a6c9e06e048f01cf4994dee194ab0ea841814/tomlkit-0.14.0-py3-none-any.whl", hash = "sha256:592064ed85b40fa213469f81ac584f67a4f2992509a7c3ea2d632208623a3680", size = 39310, upload-time = "2026-01-13T01:14:51.965Z" },
+]
+
+[[package]]
 name = "towncrier"
 version = "25.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1290,6 +1432,27 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/aa/a3/4d310fa5f00863544e1d0f4de93bddec248499ccf97d4791bc3122c9d4f3/virtualenv-20.36.1.tar.gz", hash = "sha256:8befb5c81842c641f8ee658481e42641c68b5eab3521d8e092d18320902466ba", size = 6032239, upload-time = "2026-01-09T18:21:01.296Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/6a/2a/dc2228b2888f51192c7dc766106cd475f1b768c10caaf9727659726f7391/virtualenv-20.36.1-py3-none-any.whl", hash = "sha256:575a8d6b124ef88f6f51d56d656132389f961062a9177016a50e4f507bbcc19f", size = 6008258, upload-time = "2026-01-09T18:20:59.425Z" },
+]
+
+[[package]]
+name = "wcmatch"
+version = "10.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "bracex" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/79/3e/c0bdc27cf06f4e47680bd5803a07cb3dfd17de84cde92dd217dcb9e05253/wcmatch-10.1.tar.gz", hash = "sha256:f11f94208c8c8484a16f4f48638a85d771d9513f4ab3f37595978801cb9465af", size = 117421, upload-time = "2025-06-22T19:14:02.49Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/eb/d8/0d1d2e9d3fabcf5d6840362adcf05f8cf3cd06a73358140c3a97189238ae/wcmatch-10.1-py3-none-any.whl", hash = "sha256:5848ace7dbb0476e5e55ab63c6bbd529745089343427caa5537f230cc01beb8a", size = 39854, upload-time = "2025-06-22T19:14:00.978Z" },
+]
+
+[[package]]
+name = "wcwidth"
+version = "0.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/35/a2/8e3becb46433538a38726c948d3399905a4c7cabd0df578ede5dc51f0ec2/wcwidth-0.6.0.tar.gz", hash = "sha256:cdc4e4262d6ef9a1a57e018384cbeb1208d8abbc64176027e2c2455c81313159", size = 159684, upload-time = "2026-02-06T19:19:40.919Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/68/5a/199c59e0a824a3db2b89c5d2dade7ab5f9624dbf6448dc291b46d5ec94d3/wcwidth-0.6.0-py3-none-any.whl", hash = "sha256:1a3a1e510b553315f8e146c54764f4fb6264ffad731b3d78088cdb1478ffbdad", size = 94189, upload-time = "2026-02-06T19:19:39.646Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Migrate from the deprecated `bump2version` package to `bump-my-version`, the actively maintained successor
- Use `bump-my-version bump` / `bump-my-version show` CLI commands instead of the old `bumpversion --list`
- Read the new version from `.bumpversion.cfg` after bumping instead of parsing the deprecated `--list` output, which is simpler and more robust
- No config file changes needed — `.bumpversion.cfg` format is fully backward-compatible

---

Closes https://github.com/camptocamp/odoo-project-tools/issues/139
Closes https://github.com/camptocamp/odoo-project-tools/issues/110
