### PR TITLE
[ADD] ci: auto-label PRs based on changed CLI tool

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,68 @@
+"tool:tasks":
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'odoo_tools/tasks/**'
+          - 'tests/test_tasks.py'
+
+"tool:project":
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'odoo_tools/cli/project.py'
+          - 'tests/test_project.py'
+
+"tool:addon":
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'odoo_tools/cli/addon.py'
+          - 'tests/test_addon_*.py'
+
+"tool:submodule":
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'odoo_tools/cli/submodule.py'
+          - 'tests/test_submodule.py'
+
+"tool:release":
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'odoo_tools/cli/release.py'
+          - 'tests/test_release.py'
+
+"tool:pending":
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'odoo_tools/cli/pending.py'
+
+"tool:conversion":
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'odoo_tools/conversion/**'
+
+"tool:ba":
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'odoo_tools/cli/batools.py'
+
+"tool:pr":
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'odoo_tools/cli/pr.py'
+
+"tool:migrate-db":
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'odoo_tools/cli/migrate_db.py'
+
+documentation:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'docs/**'
+          - '**/*.md'
+          - '**/*.rst'
+
+ci:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'tests/**'
+          - '.github/**'
+          - '.pre-commit-config.yaml'

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,15 @@
+name: Labeler
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v5


### PR DESCRIPTION
Adds actions/labeler config and workflow that tags PRs with the
corresponding otools-* label based on the files touched, plus meta
labels for docs, tests and ci.
