### PR TITLE
[IMP] packaging: migrate to hatchling and add --version flag

### DIFF
--- a/Releasing.md
+++ b/Releasing.md
@@ -1,14 +1,22 @@
 # how to release
 
-Run
+The package version is derived automatically from the git tag by
+[`hatch-vcs`](https://github.com/ofek/hatch-vcs), so there is no version
+number to edit in any source file.
+
+Run:
 
     export VERSION=x.y.z
     towncrier build --version=$VERSION
-    git commit -m "prepare "$VERSION
+    git commit -m "Release $VERSION"
     git tag -as $VERSION
-    # copy the content from HISTORY.rst
+    # copy the content from HISTORY.rst into the tag annotation
     git push --tags && git push
-    python3 -m build
+    uv build
 
+then create a release on https://github.com/camptocamp/odoo-project-tools/releases
+and upload the artifacts from the [dist](dist/) directory to the release.
 
-then create a release on https://github.com/camptocamp/odoo-project-tools/releases and upload the wheel you will find in the [dist](dist/) directory to the release.
+To verify the installed version at any time:
+
+    otools-project --version

--- a/changes.d/hatchling-migration.build
+++ b/changes.d/hatchling-migration.build
@@ -1,0 +1,3 @@
+Switched the build backend to ``hatchling`` + ``hatch-vcs``. The package version
+is now derived from the git tag at build time; no source file has to be edited
+on release.

--- a/changes.d/version-option.feat
+++ b/changes.d/version-option.feat
@@ -1,0 +1,3 @@
+All ``otools-*`` commands now accept a ``-V`` / ``--version`` flag that prints
+the installed ``odoo-tools`` version. The package also exposes
+``odoo_tools.__version__``.

--- a/odoo_tools/__init__.py
+++ b/odoo_tools/__init__.py
@@ -1,0 +1,9 @@
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _version
+
+try:
+    __version__ = _version("odoo-tools")
+except PackageNotFoundError:
+    __version__ = "0.0.0"
+
+__all__ = ["__version__"]

--- a/odoo_tools/cli/addon.py
+++ b/odoo_tools/cli/addon.py
@@ -6,6 +6,7 @@ import click
 
 from ..utils import req as req_utils
 from ..utils import ui
+from ..utils.click import version_option
 from ..utils.config import config
 from ..utils.misc import SmartDict
 from ..utils.path import build_path, is_odoo_module
@@ -14,6 +15,7 @@ from ..utils.pypi import odoo_name_to_pkg_name
 
 
 @click.group()
+@version_option
 def cli():
     pass
 

--- a/odoo_tools/cli/batools.py
+++ b/odoo_tools/cli/batools.py
@@ -10,6 +10,7 @@ import click
 import jinja2
 
 from ..utils import docker_compose, ui
+from ..utils.click import version_option
 from ..utils.misc import get_cache_path
 from ..utils.path import cd
 
@@ -20,6 +21,7 @@ def _check_docker_compose_file_is_old(dcfile) -> bool:
 
 
 @click.group()
+@version_option
 def cli():
     pass
 

--- a/odoo_tools/cli/cloud.py
+++ b/odoo_tools/cli/cloud.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import click
 
 from .. import utils
+from ..utils.click import version_option
 
 
 def get_customer_name_from_project_name(project_name: str) -> str:
@@ -65,6 +66,7 @@ def get_celebrimbor_dump_list(platform=None, customer=None, env="int"):
 
 @click.group()
 @click.option("--debug", is_flag=True)
+@version_option
 def cli(**kwargs):
     """Cloud platform commands."""
     pass

--- a/odoo_tools/cli/db.py
+++ b/odoo_tools/cli/db.py
@@ -17,6 +17,7 @@ console = Console()
 
 @click.group()
 @click.option("--debug", is_flag=True)
+@utils.click.version_option
 def cli(**kwargs):
     """Database management commands."""
     pass

--- a/odoo_tools/cli/i18n.py
+++ b/odoo_tools/cli/i18n.py
@@ -48,6 +48,7 @@ def _build_odoo_i18n_export_cmd(module_name, language, database, export_path):
 
 @click.group()
 @click.option("--debug", is_flag=True)
+@utils.click.version_option
 def cli(**kwargs):
     """Internationalization (i18n) commands."""
     pass

--- a/odoo_tools/cli/migrate_db.py
+++ b/odoo_tools/cli/migrate_db.py
@@ -33,6 +33,7 @@ from urllib.request import urlretrieve
 import click
 import psycopg2
 
+from ..utils.click import version_option
 from ..utils.path import build_path, root_path
 from ..utils.proj import get_current_version
 
@@ -94,6 +95,7 @@ def dt():
     is_flag=True,
     help="Do not generate database snapshots after each migration step.",
 )
+@version_option
 @click.pass_context
 def cli(
     ctx: click.Context,

--- a/odoo_tools/cli/password.py
+++ b/odoo_tools/cli/password.py
@@ -18,6 +18,7 @@ ODOO_PROJECT_URL = "https://{subdomain}.odoo.camptocamp.{country}"
 
 @click.group()
 @click.option("--debug", is_flag=True)
+@utils.click.version_option
 def cli(**kwargs):
     """Password management tools."""
 

--- a/odoo_tools/cli/pending.py
+++ b/odoo_tools/cli/pending.py
@@ -5,9 +5,11 @@ import click
 
 from ..utils import pending_merge as pm_utils
 from ..utils import ui
+from ..utils.click import version_option
 
 
 @click.group()
+@version_option
 def cli():
     pass
 

--- a/odoo_tools/cli/pr.py
+++ b/odoo_tools/cli/pr.py
@@ -6,11 +6,13 @@ from pathlib import Path
 import click
 
 from ..utils import db, docker_compose, gh, git, ui
+from ..utils.click import version_option
 from ..utils.os_exec import run
 from ..utils.path import cd, root_path
 
 
 @click.group()
+@version_option
 def cli():
     pass
 

--- a/odoo_tools/cli/project.py
+++ b/odoo_tools/cli/project.py
@@ -10,6 +10,7 @@ import jinja2
 from git import Repo as GitRepo
 
 from ..utils import git, ui
+from ..utils.click import version_option
 from ..utils.config import PROJ_CFG_FILE, config
 from ..utils.misc import (
     SmartDict,
@@ -193,6 +194,7 @@ def bootstrap_files(opts):
 
 
 @click.group()
+@version_option
 def cli():
     pass
 

--- a/odoo_tools/cli/release.py
+++ b/odoo_tools/cli/release.py
@@ -6,6 +6,7 @@ from git import Repo as GitRepo
 from rich.console import Console
 
 from ..exceptions import ProjectConfigException
+from ..utils.click import version_option
 from ..utils.config import config
 from ..utils.git import get_current_branch
 from ..utils.marabunta import MarabuntaFileHandler
@@ -88,6 +89,7 @@ def update_marabunta_file(version):
 
 
 @click.group()
+@version_option
 def cli():
     pass
 

--- a/odoo_tools/cli/submodule.py
+++ b/odoo_tools/cli/submodule.py
@@ -4,9 +4,11 @@ import click
 
 from ..utils import git, path, proj, ui
 from ..utils import pending_merge as pm_utils
+from ..utils.click import version_option
 
 
 @click.group()
+@version_option
 def cli():
     pass
 

--- a/odoo_tools/utils/click.py
+++ b/odoo_tools/utils/click.py
@@ -3,6 +3,12 @@ from functools import wraps
 
 import click
 
+from .. import __version__
+
+version_option = click.version_option(
+    __version__, "-V", "--version", package_name="odoo-tools"
+)
+
 
 def handle_exceptions() -> Callable:
     """Decorator to handle exceptions and print a nice error message.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,13 +71,22 @@ test = [
 ]
 
 [build-system]
-requires = ["setuptools>=82.0.1", "setuptools_scm[toml]>=10.0.5"]
-build-backend = "setuptools.build_meta"
+requires = ["hatchling>=1.27.0", "hatch-vcs>=0.5.0"]
+build-backend = "hatchling.build"
 
-[tool.setuptools.packages]
-find = {}
+[tool.hatch.version]
+source = "vcs"
 
-[tool.setuptools_scm]
+[tool.hatch.build.targets.wheel]
+packages = ["odoo_tools"]
+
+[tool.hatch.build.targets.sdist]
+include = [
+    "odoo_tools",
+    "HISTORY.rst",
+    "LICENSE",
+    "README.md",
+]
 
 [tool.coverage.run]
 source = ["odoo_tools"]


### PR DESCRIPTION
This PR is the first step of a broader effort to give us more control over versioning of this tooling

### What changes

- **Build backend**: switched from `setuptools` + `setuptools_scm` to `hatchling` + `hatch-vcs`. The package version is still derived from the git tag. No source file has to be edited on release.
- **`odoo_tools.__version__`**: now exposed via `importlib.metadata` as the single source of truth for the installed version.
- **`-V` / `--version` flag**: a shared `version_option` decorator in `utils/click.py` is applied to every `otools-*` entry point, so all commands report the installed version.

### Why

We want to manage the tooling's version more tightly — both to give users a clean way to check what version they are running, and to build on top of it later (update notifications and minimum-version enforcement per project).
