### PR TITLE
[ADD] ci: configure auto-generated release notes grouped by tool

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,47 @@
+changelog:
+  exclude:
+    labels:
+      - skip-changelog
+  categories:
+    - title: otools-tasks
+      labels:
+        - 'tool:tasks'
+    - title: otools-project
+      labels:
+        - 'tool:project'
+    - title: otools-addon
+      labels:
+        - 'tool:addon'
+    - title: otools-submodule
+      labels:
+        - 'tool:submodule'
+    - title: otools-release
+      labels:
+        - 'tool:release'
+    - title: otools-pending
+      labels:
+        - 'tool:pending'
+    - title: otools-conversion
+      labels:
+        - 'tool:conversion'
+    - title: otools-ba
+      labels:
+        - 'tool:ba'
+    - title: otools-pr
+      labels:
+        - 'tool:pr'
+    - title: otools-migrate-db
+      labels:
+        - 'tool:migrate-db'
+    - title: Documentation
+      labels:
+        - documentation
+    - title: CI & Tooling
+      labels:
+        - ci
+    - title: Dependencies
+      labels:
+        - dependencies
+    - title: Other Changes
+      labels:
+        - '*'


### PR DESCRIPTION

Adds `.github/release.yml` so that GitHub's **"Generate release notes"** button groups PRs by tool (using the `tool:*` labels added in #192), with additional sections for docs, CI, dependencies, and a catch-all.
