### PR TITLE
[ADD] warn when a new odoo-tools release is available

### DIFF
--- a/changes.d/update-check.feat
+++ b/changes.d/update-check.feat
@@ -1,0 +1,4 @@
+``otools-*`` commands now check once every 24 hours for a new release on
+GitHub and print a warning on stderr when one is available. The result is
+cached under ``~/.cache/otools/update-check.json``. Set
+``OTOOLS_SKIP_UPDATE_CHECK=1`` to opt out (for example in CI).

--- a/odoo_tools/cli/addon.py
+++ b/odoo_tools/cli/addon.py
@@ -6,7 +6,7 @@ import click
 
 from ..utils import req as req_utils
 from ..utils import ui
-from ..utils.click import version_option
+from ..utils.click import version_option, with_update_check
 from ..utils.config import config
 from ..utils.misc import SmartDict
 from ..utils.path import build_path, is_odoo_module
@@ -16,6 +16,7 @@ from ..utils.pypi import odoo_name_to_pkg_name
 
 @click.group()
 @version_option
+@with_update_check
 def cli():
     pass
 

--- a/odoo_tools/cli/batools.py
+++ b/odoo_tools/cli/batools.py
@@ -10,7 +10,7 @@ import click
 import jinja2
 
 from ..utils import docker_compose, ui
-from ..utils.click import version_option
+from ..utils.click import version_option, with_update_check
 from ..utils.misc import get_cache_path
 from ..utils.path import cd
 
@@ -22,6 +22,7 @@ def _check_docker_compose_file_is_old(dcfile) -> bool:
 
 @click.group()
 @version_option
+@with_update_check
 def cli():
     pass
 

--- a/odoo_tools/cli/cloud.py
+++ b/odoo_tools/cli/cloud.py
@@ -8,7 +8,7 @@ from pathlib import Path
 import click
 
 from .. import utils
-from ..utils.click import version_option
+from ..utils.click import version_option, with_update_check
 
 
 def get_customer_name_from_project_name(project_name: str) -> str:
@@ -67,6 +67,7 @@ def get_celebrimbor_dump_list(platform=None, customer=None, env="int"):
 @click.group()
 @click.option("--debug", is_flag=True)
 @version_option
+@with_update_check
 def cli(**kwargs):
     """Cloud platform commands."""
     pass

--- a/odoo_tools/cli/db.py
+++ b/odoo_tools/cli/db.py
@@ -18,6 +18,7 @@ console = Console()
 @click.group()
 @click.option("--debug", is_flag=True)
 @utils.click.version_option
+@utils.click.with_update_check
 def cli(**kwargs):
     """Database management commands."""
     pass

--- a/odoo_tools/cli/i18n.py
+++ b/odoo_tools/cli/i18n.py
@@ -49,6 +49,7 @@ def _build_odoo_i18n_export_cmd(module_name, language, database, export_path):
 @click.group()
 @click.option("--debug", is_flag=True)
 @utils.click.version_option
+@utils.click.with_update_check
 def cli(**kwargs):
     """Internationalization (i18n) commands."""
     pass

--- a/odoo_tools/cli/migrate_db.py
+++ b/odoo_tools/cli/migrate_db.py
@@ -33,7 +33,7 @@ from urllib.request import urlretrieve
 import click
 import psycopg2
 
-from ..utils.click import version_option
+from ..utils.click import version_option, with_update_check
 from ..utils.path import build_path, root_path
 from ..utils.proj import get_current_version
 
@@ -96,6 +96,7 @@ def dt():
     help="Do not generate database snapshots after each migration step.",
 )
 @version_option
+@with_update_check
 @click.pass_context
 def cli(
     ctx: click.Context,

--- a/odoo_tools/cli/password.py
+++ b/odoo_tools/cli/password.py
@@ -19,6 +19,7 @@ ODOO_PROJECT_URL = "https://{subdomain}.odoo.camptocamp.{country}"
 @click.group()
 @click.option("--debug", is_flag=True)
 @utils.click.version_option
+@utils.click.with_update_check
 def cli(**kwargs):
     """Password management tools."""
 

--- a/odoo_tools/cli/pending.py
+++ b/odoo_tools/cli/pending.py
@@ -5,11 +5,12 @@ import click
 
 from ..utils import pending_merge as pm_utils
 from ..utils import ui
-from ..utils.click import version_option
+from ..utils.click import version_option, with_update_check
 
 
 @click.group()
 @version_option
+@with_update_check
 def cli():
     pass
 

--- a/odoo_tools/cli/pr.py
+++ b/odoo_tools/cli/pr.py
@@ -6,13 +6,14 @@ from pathlib import Path
 import click
 
 from ..utils import db, docker_compose, gh, git, ui
-from ..utils.click import version_option
+from ..utils.click import version_option, with_update_check
 from ..utils.os_exec import run
 from ..utils.path import cd, root_path
 
 
 @click.group()
 @version_option
+@with_update_check
 def cli():
     pass
 

--- a/odoo_tools/cli/project.py
+++ b/odoo_tools/cli/project.py
@@ -10,7 +10,7 @@ import jinja2
 from git import Repo as GitRepo
 
 from ..utils import git, ui
-from ..utils.click import version_option
+from ..utils.click import version_option, with_update_check
 from ..utils.config import PROJ_CFG_FILE, config
 from ..utils.misc import (
     SmartDict,
@@ -195,6 +195,7 @@ def bootstrap_files(opts):
 
 @click.group()
 @version_option
+@with_update_check
 def cli():
     pass
 

--- a/odoo_tools/cli/release.py
+++ b/odoo_tools/cli/release.py
@@ -6,7 +6,7 @@ from git import Repo as GitRepo
 from rich.console import Console
 
 from ..exceptions import ProjectConfigException
-from ..utils.click import version_option
+from ..utils.click import version_option, with_update_check
 from ..utils.config import config
 from ..utils.git import get_current_branch
 from ..utils.marabunta import MarabuntaFileHandler
@@ -90,6 +90,7 @@ def update_marabunta_file(version):
 
 @click.group()
 @version_option
+@with_update_check
 def cli():
     pass
 

--- a/odoo_tools/cli/submodule.py
+++ b/odoo_tools/cli/submodule.py
@@ -4,11 +4,12 @@ import click
 
 from ..utils import git, path, proj, ui
 from ..utils import pending_merge as pm_utils
-from ..utils.click import version_option
+from ..utils.click import version_option, with_update_check
 
 
 @click.group()
 @version_option
+@with_update_check
 def cli():
     pass
 

--- a/odoo_tools/utils/click.py
+++ b/odoo_tools/utils/click.py
@@ -4,6 +4,9 @@ from functools import wraps
 import click
 
 from .. import __version__
+from .update_check import with_update_check
+
+__all__ = ["handle_exceptions", "version_option", "with_update_check"]
 
 version_option = click.version_option(
     __version__, "-V", "--version", package_name="odoo-tools"

--- a/odoo_tools/utils/update_check.py
+++ b/odoo_tools/utils/update_check.py
@@ -1,0 +1,129 @@
+# Copyright 2026 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+
+"""Check GitHub Releases for a newer version of odoo-tools.
+
+The check runs at most once every 24 hours — the result is cached on disk.
+Failures (network error, rate limit, bad response) are swallowed so they
+never interrupt the user's command.
+"""
+
+import json
+import logging
+import os
+import sys
+from datetime import datetime, timedelta
+from functools import wraps
+from pathlib import Path
+
+import click
+import requests
+from packaging.version import InvalidVersion, Version
+
+from .. import __version__
+from .misc import get_cache_path
+
+logger = logging.getLogger(__name__)
+
+REPO = "camptocamp/odoo-project-tools"
+REPO_URL = f"https://github.com/{REPO}"
+RELEASES_URL = f"https://api.github.com/repos/{REPO}/releases/latest"
+CACHE_FILE_NAME = "update-check.json"
+CHECK_INTERVAL = timedelta(hours=24)
+FETCH_TIMEOUT = 2.0
+SKIP_ENV_VAR = "OTOOLS_SKIP_UPDATE_CHECK"
+
+
+def _fetch_latest_version() -> str | None:
+    try:
+        response = requests.get(RELEASES_URL, timeout=FETCH_TIMEOUT)
+        response.raise_for_status()
+        data = response.json()
+    except (requests.RequestException, ValueError) as exc:
+        logger.debug("Failed to fetch latest odoo-tools version: %s", exc)
+        return None
+    tag = data.get("tag_name")
+    if not tag:
+        return None
+    return tag.removeprefix("v")
+
+
+def get_latest_version() -> str | None:
+    """Return the latest released version, reading from the 24h cache when fresh."""
+    path = get_cache_path() / CACHE_FILE_NAME
+    try:
+        cached = json.loads(path.read_text())
+        checked_at = datetime.fromisoformat(cached["checked_at"])
+        if datetime.now() - checked_at < CHECK_INTERVAL:
+            return cached["latest_version"]
+    except (OSError, ValueError, KeyError) as exc:
+        logger.debug("Cannot read update-check cache: %s", exc)
+    latest = _fetch_latest_version()
+    if latest:
+        try:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(
+                json.dumps(
+                    {
+                        "checked_at": datetime.now().isoformat(),
+                        "latest_version": latest,
+                    }
+                )
+            )
+        except OSError as exc:
+            logger.debug("Cannot write update-check cache: %s", exc)
+    return latest
+
+
+def _compare(current: str, latest: str) -> bool:
+    """Return True if `latest` is strictly greater than `current`."""
+    try:
+        return Version(latest) > Version(current)
+    except InvalidVersion:
+        return False
+
+
+def _upgrade_command(prefix: str | None = None) -> str:
+    """Return the best-guess upgrade command for the current install layout."""
+    prefix = prefix or sys.prefix
+    parts = Path(prefix).parts
+    if "pipx" in parts:
+        return "pipx upgrade odoo-tools"
+    # uv tool installs live under ".../uv/tools/<pkg>/..."
+    if "uv/tools" in Path(prefix).as_posix():
+        return "uv tool upgrade odoo-tools"
+    return f"pip install --upgrade git+{REPO_URL}"
+
+
+def check_for_update() -> None:
+    """Warn the user on stderr if a newer release is available.
+
+    Never raises. Honors ``OTOOLS_SKIP_UPDATE_CHECK`` to opt out entirely.
+    """
+    if os.getenv(SKIP_ENV_VAR):
+        return
+    latest = get_latest_version()
+    if not latest or not _compare(__version__, latest):
+        return
+    click.secho(
+        f"A new version of odoo-tools is available: {latest} "
+        f"(installed: {__version__})\n"
+        f"  Update with: {_upgrade_command()}",
+        fg="yellow",
+        err=True,
+    )
+
+
+def with_update_check(func):
+    """Decorator for click group/command callbacks: run ``check_for_update`` first.
+
+    Click's eager ``--help`` and ``--version`` exit before the callback runs,
+    so the check is naturally skipped for those flags.
+    """
+
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        check_for_update()
+        return func(*args, **kwargs)
+
+    return wrapper

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -72,3 +72,13 @@ def all_template_versions(project):
 @pytest.fixture(autouse=True)
 def clear_caches():
     get_project_manifest.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def skip_update_check(monkeypatch):
+    """Disable the update check for every test.
+
+    The tests that exercise the check itself opt in by clearing this
+    environment variable in their own fixture.
+    """
+    monkeypatch.setenv("OTOOLS_SKIP_UPDATE_CHECK", "1")

--- a/tests/test_utils_update_check.py
+++ b/tests/test_utils_update_check.py
@@ -1,0 +1,191 @@
+# Copyright 2026 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+
+import json
+from datetime import datetime, timedelta
+from unittest.mock import patch
+
+import pytest
+import responses
+
+from odoo_tools.utils import update_check
+
+
+@pytest.fixture(autouse=True)
+def allow_update_check(monkeypatch):
+    """Re-enable the update check for this module.
+
+    ``tests/conftest.py`` sets ``OTOOLS_SKIP_UPDATE_CHECK`` globally to
+    keep the check out of every other test; unset it here so the tests
+    that exercise the check itself actually run.
+    """
+    monkeypatch.delenv("OTOOLS_SKIP_UPDATE_CHECK", raising=False)
+
+
+@pytest.fixture
+def cache_dir(tmp_path):
+    """Redirect the update-check cache to a temp directory."""
+    with patch.object(update_check, "get_cache_path", return_value=tmp_path):
+        yield tmp_path
+
+
+@pytest.fixture
+def mocked_releases():
+    with responses.RequestsMock() as rsps:
+        yield rsps
+
+
+def _add_release(rsps, tag):
+    rsps.add(
+        responses.GET,
+        update_check.RELEASES_URL,
+        json={"tag_name": tag},
+        status=200,
+        content_type="application/json",
+    )
+
+
+def test_fetch_writes_cache(cache_dir, mocked_releases):
+    _add_release(mocked_releases, "1.2.3")
+    assert update_check.get_latest_version() == "1.2.3"
+    cached = json.loads((cache_dir / update_check.CACHE_FILE_NAME).read_text())
+    assert cached["latest_version"] == "1.2.3"
+
+
+def test_tag_v_prefix_is_stripped(cache_dir, mocked_releases):
+    _add_release(mocked_releases, "v2.0.0")
+    assert update_check.get_latest_version() == "2.0.0"
+
+
+def test_fresh_cache_skips_network(cache_dir):
+    (cache_dir / update_check.CACHE_FILE_NAME).write_text(
+        json.dumps(
+            {
+                "checked_at": datetime.now().isoformat(),
+                "latest_version": "5.0.0",
+            }
+        )
+    )
+    # No mocked response — a real request would raise ConnectionError
+    with responses.RequestsMock():
+        assert update_check.get_latest_version() == "5.0.0"
+
+
+def test_stale_cache_triggers_refetch(cache_dir, mocked_releases):
+    stale = datetime.now() - timedelta(hours=25)
+    (cache_dir / update_check.CACHE_FILE_NAME).write_text(
+        json.dumps({"checked_at": stale.isoformat(), "latest_version": "0.1.0"})
+    )
+    _add_release(mocked_releases, "9.9.9")
+    assert update_check.get_latest_version() == "9.9.9"
+
+
+def test_network_error_returns_none(cache_dir, mocked_releases):
+    mocked_releases.add(responses.GET, update_check.RELEASES_URL, status=500)
+    assert update_check.get_latest_version() is None
+    assert not (cache_dir / update_check.CACHE_FILE_NAME).exists()
+
+
+def test_malformed_cache_falls_back_to_fetch(cache_dir, mocked_releases):
+    (cache_dir / update_check.CACHE_FILE_NAME).write_text("not-json")
+    _add_release(mocked_releases, "1.0.0")
+    assert update_check.get_latest_version() == "1.0.0"
+
+
+@pytest.mark.parametrize(
+    "current,latest,expected",
+    [
+        ("0.13.0", "0.14.0", True),
+        ("0.14.0", "0.13.0", False),
+        ("0.14.0", "0.14.0", False),
+        # Dev build of a newer series vs. older release: dev is ahead.
+        ("0.14.0.dev1+gabcdef", "0.13.0", False),
+        # Dev build is outdated once its base version is released.
+        ("0.15.0.dev1+gabcdef", "0.15.0", True),
+        # Dev build is outdated when a later release is out.
+        ("0.14.0.dev1+gabcdef", "0.15.0", True),
+        # Unparsable version: never warn, never crash.
+        ("not-a-version", "1.0.0", False),
+    ],
+)
+def test_compare(current, latest, expected):
+    assert update_check._compare(current, latest) is expected
+
+
+@pytest.mark.parametrize(
+    "prefix,expected",
+    [
+        ("/home/user/.local/pipx/venvs/odoo-tools", "pipx upgrade odoo-tools"),
+        (
+            "/home/user/.local/share/uv/tools/odoo-tools",
+            "uv tool upgrade odoo-tools",
+        ),
+        (
+            "/home/user/venvs/something",
+            f"pip install --upgrade git+{update_check.REPO_URL}",
+        ),
+    ],
+)
+def test_upgrade_command(prefix, expected):
+    assert update_check._upgrade_command(prefix) == expected
+
+
+def test_check_for_update_prints_warning(cache_dir, mocked_releases, capsys):
+    _add_release(mocked_releases, "99.0.0")
+    with patch.object(update_check, "__version__", "0.13.0"):
+        update_check.check_for_update()
+    captured = capsys.readouterr()
+    assert "99.0.0" in captured.err
+    assert "odoo-tools" in captured.err
+
+
+def test_check_for_update_silent_when_up_to_date(cache_dir, mocked_releases, capsys):
+    _add_release(mocked_releases, "0.13.0")
+    with patch.object(update_check, "__version__", "0.13.0"):
+        update_check.check_for_update()
+    assert capsys.readouterr().err == ""
+
+
+def test_skip_via_env_var(cache_dir, monkeypatch, capsys):
+    monkeypatch.setenv(update_check.SKIP_ENV_VAR, "1")
+    with responses.RequestsMock():  # would fail on any HTTP call
+        update_check.check_for_update()
+    assert capsys.readouterr().err == ""
+    assert not (cache_dir / update_check.CACHE_FILE_NAME).exists()
+
+
+def test_check_silent_when_fetch_fails(cache_dir, mocked_releases, capsys):
+    mocked_releases.add(responses.GET, update_check.RELEASES_URL, status=500)
+    update_check.check_for_update()
+    assert capsys.readouterr().err == ""
+
+
+def test_check_for_update_suggests_detected_install_method(
+    cache_dir, mocked_releases, capsys
+):
+    _add_release(mocked_releases, "99.0.0")
+    with (
+        patch.object(update_check, "__version__", "0.13.0"),
+        patch.object(
+            update_check, "_upgrade_command", return_value="pipx upgrade odoo-tools"
+        ),
+    ):
+        update_check.check_for_update()
+    assert "pipx upgrade odoo-tools" in capsys.readouterr().err
+
+
+def test_with_update_check_decorator_invokes_check():
+    calls = []
+
+    def fake_check():
+        calls.append("checked")
+
+    @update_check.with_update_check
+    def command(x, y=2):
+        return x + y
+
+    with patch.object(update_check, "check_for_update", fake_check):
+        result = command(1, y=4)
+
+    assert result == 5
+    assert calls == ["checked"]


### PR DESCRIPTION
Builds on top of:
- #193.

`otools-*` commands now check once every 24 hours whether a newer release is available on GitHub, and print a warning on stderr when one is. The result is cached on disk so the network call runs at most once per day.

Users today have no way of knowing they are running an old version of the tooling. A passive once-per-day check keeps them aware without being invasive, and costs one HTTP request per machine per day at most.
