### PR TITLE
[ADD] enforce `otools_min_version` declared in .proj.cfg

### DIFF
--- a/changes.d/minimum-version.feat
+++ b/changes.d/minimum-version.feat
@@ -1,0 +1,5 @@
+A project's ``.proj.cfg`` can now declare ``otools_min_version``, the
+minimum version of ``odoo-tools`` required to operate on that project.
+When the installed version is older, every ``otools-*`` command exits
+with a clear error pointing to the required version and the upgrade
+command for the detected install layout.

--- a/odoo_tools/cli/addon.py
+++ b/odoo_tools/cli/addon.py
@@ -6,7 +6,7 @@ import click
 
 from ..utils import req as req_utils
 from ..utils import ui
-from ..utils.click import version_option, with_update_check
+from ..utils.click import global_command_decorators
 from ..utils.config import config
 from ..utils.misc import SmartDict
 from ..utils.path import build_path, is_odoo_module
@@ -15,8 +15,7 @@ from ..utils.pypi import odoo_name_to_pkg_name
 
 
 @click.group()
-@version_option
-@with_update_check
+@global_command_decorators
 def cli():
     pass
 

--- a/odoo_tools/cli/batools.py
+++ b/odoo_tools/cli/batools.py
@@ -10,7 +10,7 @@ import click
 import jinja2
 
 from ..utils import docker_compose, ui
-from ..utils.click import version_option, with_update_check
+from ..utils.click import global_command_decorators
 from ..utils.misc import get_cache_path
 from ..utils.path import cd
 
@@ -21,8 +21,7 @@ def _check_docker_compose_file_is_old(dcfile) -> bool:
 
 
 @click.group()
-@version_option
-@with_update_check
+@global_command_decorators
 def cli():
     pass
 

--- a/odoo_tools/cli/cloud.py
+++ b/odoo_tools/cli/cloud.py
@@ -8,7 +8,7 @@ from pathlib import Path
 import click
 
 from .. import utils
-from ..utils.click import version_option, with_update_check
+from ..utils.click import global_command_decorators
 
 
 def get_customer_name_from_project_name(project_name: str) -> str:
@@ -66,8 +66,7 @@ def get_celebrimbor_dump_list(platform=None, customer=None, env="int"):
 
 @click.group()
 @click.option("--debug", is_flag=True)
-@version_option
-@with_update_check
+@global_command_decorators
 def cli(**kwargs):
     """Cloud platform commands."""
     pass

--- a/odoo_tools/cli/db.py
+++ b/odoo_tools/cli/db.py
@@ -17,8 +17,7 @@ console = Console()
 
 @click.group()
 @click.option("--debug", is_flag=True)
-@utils.click.version_option
-@utils.click.with_update_check
+@utils.click.global_command_decorators
 def cli(**kwargs):
     """Database management commands."""
     pass

--- a/odoo_tools/cli/i18n.py
+++ b/odoo_tools/cli/i18n.py
@@ -48,8 +48,7 @@ def _build_odoo_i18n_export_cmd(module_name, language, database, export_path):
 
 @click.group()
 @click.option("--debug", is_flag=True)
-@utils.click.version_option
-@utils.click.with_update_check
+@utils.click.global_command_decorators
 def cli(**kwargs):
     """Internationalization (i18n) commands."""
     pass

--- a/odoo_tools/cli/migrate_db.py
+++ b/odoo_tools/cli/migrate_db.py
@@ -33,7 +33,7 @@ from urllib.request import urlretrieve
 import click
 import psycopg2
 
-from ..utils.click import version_option, with_update_check
+from ..utils.click import global_command_decorators
 from ..utils.path import build_path, root_path
 from ..utils.proj import get_current_version
 
@@ -95,8 +95,7 @@ def dt():
     is_flag=True,
     help="Do not generate database snapshots after each migration step.",
 )
-@version_option
-@with_update_check
+@global_command_decorators
 @click.pass_context
 def cli(
     ctx: click.Context,

--- a/odoo_tools/cli/password.py
+++ b/odoo_tools/cli/password.py
@@ -18,8 +18,7 @@ ODOO_PROJECT_URL = "https://{subdomain}.odoo.camptocamp.{country}"
 
 @click.group()
 @click.option("--debug", is_flag=True)
-@utils.click.version_option
-@utils.click.with_update_check
+@utils.click.global_command_decorators
 def cli(**kwargs):
     """Password management tools."""
 

--- a/odoo_tools/cli/pending.py
+++ b/odoo_tools/cli/pending.py
@@ -5,12 +5,11 @@ import click
 
 from ..utils import pending_merge as pm_utils
 from ..utils import ui
-from ..utils.click import version_option, with_update_check
+from ..utils.click import global_command_decorators
 
 
 @click.group()
-@version_option
-@with_update_check
+@global_command_decorators
 def cli():
     pass
 

--- a/odoo_tools/cli/pr.py
+++ b/odoo_tools/cli/pr.py
@@ -6,14 +6,13 @@ from pathlib import Path
 import click
 
 from ..utils import db, docker_compose, gh, git, ui
-from ..utils.click import version_option, with_update_check
+from ..utils.click import global_command_decorators
 from ..utils.os_exec import run
 from ..utils.path import cd, root_path
 
 
 @click.group()
-@version_option
-@with_update_check
+@global_command_decorators
 def cli():
     pass
 

--- a/odoo_tools/cli/project.py
+++ b/odoo_tools/cli/project.py
@@ -10,7 +10,7 @@ import jinja2
 from git import Repo as GitRepo
 
 from ..utils import git, ui
-from ..utils.click import version_option, with_update_check
+from ..utils.click import global_command_decorators
 from ..utils.config import PROJ_CFG_FILE, config
 from ..utils.misc import (
     SmartDict,
@@ -194,8 +194,7 @@ def bootstrap_files(opts):
 
 
 @click.group()
-@version_option
-@with_update_check
+@global_command_decorators
 def cli():
     pass
 

--- a/odoo_tools/cli/release.py
+++ b/odoo_tools/cli/release.py
@@ -6,7 +6,7 @@ from git import Repo as GitRepo
 from rich.console import Console
 
 from ..exceptions import ProjectConfigException
-from ..utils.click import version_option, with_update_check
+from ..utils.click import global_command_decorators
 from ..utils.config import config
 from ..utils.git import get_current_branch
 from ..utils.marabunta import MarabuntaFileHandler
@@ -89,8 +89,7 @@ def update_marabunta_file(version):
 
 
 @click.group()
-@version_option
-@with_update_check
+@global_command_decorators
 def cli():
     pass
 

--- a/odoo_tools/cli/submodule.py
+++ b/odoo_tools/cli/submodule.py
@@ -4,12 +4,11 @@ import click
 
 from ..utils import git, path, proj, ui
 from ..utils import pending_merge as pm_utils
-from ..utils.click import version_option, with_update_check
+from ..utils.click import global_command_decorators
 
 
 @click.group()
-@version_option
-@with_update_check
+@global_command_decorators
 def cli():
     pass
 

--- a/odoo_tools/templates/.proj.v1.cfg
+++ b/odoo_tools/templates/.proj.v1.cfg
@@ -10,3 +10,6 @@ local_src_rel_path = odoo/local-src
 pending_merge_rel_path = pending-merges.d
 version_file_rel_path = odoo/VERSION
 marabunta_mig_file_rel_path = odoo/migration.yml
+# Minimum required odoo-tools version for this project.
+# Leave unset to allow any installed version.
+# otools_min_version = 0.14.0

--- a/odoo_tools/templates/.proj.v2.cfg
+++ b/odoo_tools/templates/.proj.v2.cfg
@@ -12,3 +12,6 @@ local_src_rel_path = odoo/addons
 pending_merge_rel_path = pending-merges.d
 version_file_rel_path = VERSION
 marabunta_mig_file_rel_path = migration.yml
+# Minimum required odoo-tools version for this project.
+# Leave unset to allow any installed version.
+# otools_min_version = 0.14.0

--- a/odoo_tools/utils/click.py
+++ b/odoo_tools/utils/click.py
@@ -4,13 +4,34 @@ from functools import wraps
 import click
 
 from .. import __version__
+from .minimum_version import with_minimum_version_check
 from .update_check import with_update_check
 
-__all__ = ["handle_exceptions", "version_option", "with_update_check"]
+__all__ = [
+    "handle_exceptions",
+    "global_command_decorators",
+    "version_option",
+    "with_minimum_version_check",
+    "with_update_check",
+]
 
 version_option = click.version_option(
     __version__, "-V", "--version", package_name="odoo-tools"
 )
+
+
+def global_command_decorators(func):
+    """Apply the standard ``otools-*`` pre-invoke hooks.
+
+    Bundles (in order): update-available check, project ``otools_min_version``
+    enforcement, and the ``-V`` / ``--version`` flag. Place it right above
+    ``def cli(...):`` so it wraps the callback; ``@click.group()`` /
+    ``@click.command()`` and any CLI-specific options stay where they are.
+    """
+    func = with_update_check(func)
+    func = with_minimum_version_check(func)
+    func = version_option(func)
+    return func
 
 
 def handle_exceptions() -> Callable:

--- a/odoo_tools/utils/config.py
+++ b/odoo_tools/utils/config.py
@@ -10,7 +10,14 @@ from pathlib import Path
 from textwrap import indent
 from typing import Annotated, Any
 
-from pydantic import BaseModel, BeforeValidator, ConfigDict, ValidationError
+from packaging.version import InvalidVersion, Version
+from pydantic import (
+    BaseModel,
+    BeforeValidator,
+    ConfigDict,
+    ValidationError,
+    field_validator,
+)
 
 from ..exceptions import ProjectConfigException
 from .misc import parse_ini_cfg
@@ -102,6 +109,25 @@ class ProjectConfig(BaseModel):
 
     marabunta_mig_file_rel_path: OptionalPath = None
     """The path to the Marabunta migration file."""
+
+    otools_min_version: Annotated[str | None, BeforeValidator(falsy_to_none)] = None
+    """The minimum required version of odoo-tools to operate on this project.
+
+    If set, any ``otools-*`` command will refuse to run when the installed
+    version is lower than this one. Useful to enforce a baseline on shared
+    projects. Example: ``otools_min_version = 0.14.0``.
+    """
+
+    @field_validator("otools_min_version")
+    @classmethod
+    def _validate_otools_min_version(cls, v: str | None) -> str | None:
+        if v is None:
+            return v
+        try:
+            Version(v)
+        except InvalidVersion as exc:
+            raise ValueError(f"not a valid version string: {v!r}") from exc
+        return v
 
 
 class LazyConfig:

--- a/odoo_tools/utils/minimum_version.py
+++ b/odoo_tools/utils/minimum_version.py
@@ -1,0 +1,57 @@
+# Copyright 2026 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+
+"""Enforce a minimum odoo-tools version per project.
+
+Projects can declare ``otools_min_version`` in ``.proj.cfg``. When the
+installed ``odoo-tools`` is older, every ``otools-*`` command refuses
+to run and prints the required version together with the upgrade
+command for the detected install layout.
+"""
+
+from functools import wraps
+
+import click
+from packaging.version import Version
+
+from .. import __version__
+from ..exceptions import ProjectConfigException, ProjectRootFolderNotFound
+from .config import config
+from .update_check import upgrade_command
+
+
+def check_minimum_version() -> None:
+    """Raise ``click.ClickException`` if the installed version is too old.
+
+    No-op when there is no reachable ``.proj.cfg`` (running outside a
+    project, or before ``otools-project init``) or when the project
+    does not set ``otools_min_version``.
+    """
+    try:
+        minimum = config.otools_min_version
+    except (ProjectConfigException, ProjectRootFolderNotFound):
+        return
+    if not minimum:
+        return
+    if Version(__version__) >= Version(minimum):
+        return
+    raise click.ClickException(
+        f"This project requires odoo-tools {minimum} or newer, "
+        f"but {__version__} is installed.\n"
+        f"  Update with: {upgrade_command()}"
+    )
+
+
+def with_minimum_version_check(func):
+    """Decorator: enforce ``otools_min_version`` before running the callback.
+
+    Click's ``--help`` and ``--version`` are eager and exit before the
+    callback runs, so they are naturally exempt from the check.
+    """
+
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        check_minimum_version()
+        return func(*args, **kwargs)
+
+    return wrapper

--- a/odoo_tools/utils/update_check.py
+++ b/odoo_tools/utils/update_check.py
@@ -83,7 +83,7 @@ def _compare(current: str, latest: str) -> bool:
         return False
 
 
-def _upgrade_command(prefix: str | None = None) -> str:
+def upgrade_command(prefix: str | None = None) -> str:
     """Return the best-guess upgrade command for the current install layout."""
     prefix = prefix or sys.prefix
     parts = Path(prefix).parts
@@ -108,7 +108,7 @@ def check_for_update() -> None:
     click.secho(
         f"A new version of odoo-tools is available: {latest} "
         f"(installed: {__version__})\n"
-        f"  Update with: {_upgrade_command()}",
+        f"  Update with: {upgrade_command()}",
         fg="yellow",
         err=True,
     )

--- a/tests/test_utils_minimum_version.py
+++ b/tests/test_utils_minimum_version.py
@@ -1,0 +1,159 @@
+# Copyright 2026 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+
+from pathlib import Path
+from unittest.mock import patch
+
+import click
+import pytest
+
+from odoo_tools.exceptions import ProjectConfigException, ProjectRootFolderNotFound
+from odoo_tools.utils import minimum_version
+from odoo_tools.utils.config import ProjectConfig
+
+
+def _fake_config(otools_min_version: str = "") -> ProjectConfig:
+    return ProjectConfig(
+        company_git_remote="camptocamp",
+        odoo_src_rel_path=Path("odoo/src"),
+        ext_src_rel_path=Path("odoo/external-src"),
+        local_src_rel_path=Path("odoo/local-src"),
+        pending_merge_rel_path=Path("pending-merges.d"),
+        otools_min_version=otools_min_version,
+    )
+
+
+def _mock_config(**attrs):
+    """Patch ``config`` attribute access to return the given values.
+
+    Anything not in ``attrs`` raises ``AttributeError`` when accessed,
+    which mirrors how the real ``LazyConfig`` behaves when the loaded
+    ``ProjectConfig`` lacks that field.
+    """
+
+    class _FakeConfig:
+        def __getattr__(self, name):
+            if name in attrs:
+                return attrs[name]
+            raise AttributeError(name)
+
+    return patch.object(minimum_version, "config", _FakeConfig())
+
+
+def test_no_config_is_noop():
+    with patch.object(
+        type(minimum_version.config),
+        "__getattr__",
+        side_effect=ProjectConfigException("no .proj.cfg"),
+    ):
+        minimum_version.check_minimum_version()
+
+
+def test_outside_project_root_is_noop():
+    with patch.object(
+        type(minimum_version.config),
+        "__getattr__",
+        side_effect=ProjectRootFolderNotFound("no marker"),
+    ):
+        minimum_version.check_minimum_version()
+
+
+def test_unset_minimum_version_is_noop():
+    with _mock_config(otools_min_version=None):
+        minimum_version.check_minimum_version()
+
+
+def test_installed_version_meets_minimum():
+    with (
+        _mock_config(otools_min_version="0.10.0"),
+        patch.object(minimum_version, "__version__", "0.14.0"),
+    ):
+        minimum_version.check_minimum_version()
+
+
+def test_installed_version_equal_to_minimum_passes():
+    with (
+        _mock_config(otools_min_version="0.14.0"),
+        patch.object(minimum_version, "__version__", "0.14.0"),
+    ):
+        minimum_version.check_minimum_version()
+
+
+def test_installed_version_below_minimum_raises():
+    with (
+        _mock_config(otools_min_version="0.14.0"),
+        patch.object(minimum_version, "__version__", "0.13.0"),
+        patch.object(
+            minimum_version,
+            "upgrade_command",
+            return_value="uv tool upgrade odoo-tools",
+        ),
+        pytest.raises(click.ClickException) as excinfo,
+    ):
+        minimum_version.check_minimum_version()
+    message = excinfo.value.message
+    assert "0.14.0" in message
+    assert "0.13.0" in message
+    assert "uv tool upgrade odoo-tools" in message
+
+
+def test_dev_build_ahead_of_minimum_passes():
+    """A dev build of a newer series is considered newer than the base."""
+    with (
+        _mock_config(otools_min_version="0.14.0"),
+        patch.object(minimum_version, "__version__", "0.15.0.dev1+gabcdef"),
+    ):
+        minimum_version.check_minimum_version()
+
+
+def test_decorator_invokes_check():
+    calls = []
+
+    def fake_check():
+        calls.append("checked")
+
+    @minimum_version.with_minimum_version_check
+    def command(x):
+        return x * 2
+
+    with patch.object(minimum_version, "check_minimum_version", fake_check):
+        result = command(3)
+
+    assert result == 6
+    assert calls == ["checked"]
+
+
+def test_decorator_propagates_failure():
+    def failing_check():
+        raise click.ClickException("nope")
+
+    @minimum_version.with_minimum_version_check
+    def command():
+        return "should not run"
+
+    with (
+        patch.object(minimum_version, "check_minimum_version", failing_check),
+        pytest.raises(click.ClickException),
+    ):
+        command()
+
+
+@pytest.mark.parametrize(
+    "value",
+    ["0.14.0", "1.2.3", "0.14.0.dev1"],
+)
+def test_config_accepts_valid_minimum_version(value):
+    cfg = _fake_config(otools_min_version=value)
+    assert cfg.otools_min_version == value
+
+
+def test_config_rejects_malformed_minimum_version():
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        _fake_config(otools_min_version="not-a-version")
+
+
+def test_config_empty_minimum_version_is_none():
+    cfg = _fake_config(otools_min_version="")
+    assert cfg.otools_min_version is None

--- a/tests/test_utils_update_check.py
+++ b/tests/test_utils_update_check.py
@@ -127,7 +127,7 @@ def test_compare(current, latest, expected):
     ],
 )
 def test_upgrade_command(prefix, expected):
-    assert update_check._upgrade_command(prefix) == expected
+    assert update_check.upgrade_command(prefix) == expected
 
 
 def test_check_for_update_prints_warning(cache_dir, mocked_releases, capsys):
@@ -167,7 +167,7 @@ def test_check_for_update_suggests_detected_install_method(
     with (
         patch.object(update_check, "__version__", "0.13.0"),
         patch.object(
-            update_check, "_upgrade_command", return_value="pipx upgrade odoo-tools"
+            update_check, "upgrade_command", return_value="pipx upgrade odoo-tools"
         ),
     ):
         update_check.check_for_update()


### PR DESCRIPTION
Lets a project pin the minimum `odoo-tools` version required to operate on it, and refuses to run any `otools-*` command when the installed version is older.

Built on top of:
- https://github.com/camptocamp/odoo-project-tools/pull/193
- https://github.com/camptocamp/odoo-project-tools/pull/195
