### PR TITLE
Improve otools-pending show

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,11 @@ aggregating branches, and adding or removing pending merges.
 
 Commands:
     - `show`: List pull requests for specified repositories or all repositories
-      in the pending folder. Supports filtering by state and purging closed or
-      merged pull requests.
+      in the pending folder. Pass `--no-check` to skip the GitHub API lookup
+      and produce a local-only listing. Pass `--json` to emit a JSON array
+      with all available fields instead of human-readable text.
+    - `clean`: Remove merged pull requests from pending-merge files and
+      re-aggregate the affected repositories.
     - `aggregate`: Perform a git aggregation on a specified repository and push
       the result to a remote branch if desired.
     - `add`: Add a pending merge using a given entity URL. Optionally, run git

--- a/odoo_tools/cli/pending.py
+++ b/odoo_tools/cli/pending.py
@@ -137,10 +137,12 @@ def clean_pending(repo_paths=(), aggregate=True):
         for pr in all_prs:
             if not pr.is_enriched:
                 state_cell, outcome = Spinner("dots"), ""
-            else:
+            elif id(pr) in removed:
                 state = "merged" if pr.merged else pr.state
                 state_cell = f"[{PR_STATE_STYLES.get(state, 'white')}]●[/]"
-                outcome = "[green]removed[/]" if id(pr) in removed else ""
+                outcome = "[green]removed[/]"
+            else:
+                continue  # enriched but not removed — nothing to do here
             grid.add_row(
                 state_cell,
                 f"[link={pr.url}]{pr.shortcut}[/link]",

--- a/odoo_tools/cli/pending.py
+++ b/odoo_tools/cli/pending.py
@@ -1,17 +1,34 @@
 # Copyright 2023 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 
+import json
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+import arrow
 import click
+from rich.console import Console
+from rich.live import Live
+from rich.spinner import Spinner
+from rich.table import Table
 
 from ..utils import pending_merge as pm_utils
-from ..utils import ui
-from ..utils.click import global_command_decorators
+from ..utils.click import deprecated_option, global_command_decorators
+
+console = Console()
+
+PR_STATE_STYLES = {"open": "green", "closed": "red", "merged": "magenta"}
 
 
 @click.group()
 @global_command_decorators
 def cli():
     pass
+
+
+def _resolve_repos(repo_paths):
+    if not repo_paths:
+        return pm_utils.Repo.repositories_from_pending_folder()
+    return [pm_utils.Repo(repo_path) for repo_path in repo_paths]
 
 
 @cli.command(name="show")
@@ -21,36 +38,144 @@ def cli():
     nargs=-1,
 )
 @click.option(
-    "-s",
-    "--state",
-    "state",
-    help="only list pull requests in the specified state",
-    type=click.Choice(["open", "merged", "closed"], case_sensitive=False),
-)
-@click.option(
-    "-p",
-    "--purge",
-    "purge",
-    help="remove the pull request in a state matching the value if the option from the git-aggregator file",
-    type=click.Choice(["closed", "merged"], case_sensitive=False),
-)
-@click.option(
-    "--yes-all/--no-all",
-    "yes_all",
+    "--check/--no-check",
+    "check",
     is_flag=True,
     default=True,
-    help="assume yes to all questions, useful for automation",
+    help="Check each pull request's state via the GitHub API",
 )
-def show_pending(repo_paths=(), state=None, purge=None, yes_all=True):
-    """List pull requests on <repo_path>"""
-    if yes_all:
-        ui.echo("``--yes-all`` flag on -> Assuming yes to all questions")
-    if not repo_paths:
-        repositories = pm_utils.Repo.repositories_from_pending_folder()
+@click.option(
+    "--json",
+    "as_json",
+    is_flag=True,
+    default=False,
+    help="Output as JSON",
+)
+@deprecated_option(
+    "--purge",
+    message="`--purge` has been removed from `otools-pending show`. "
+    "Use `otools-pending clean` instead.",
+)
+def show_pending(repo_paths=(), check=True, as_json=False):
+    """List pull requests on <repo_path>."""
+    repos = _resolve_repos(repo_paths)
+    all_prs = [pr for repo in repos for pr in repo._iter_pending_pull_requests()]
+    # In case of --json, output directly
+    if as_json:
+        if check:
+            with ThreadPoolExecutor(max_workers=8) as pool:
+                list(pool.map(lambda pr: pr.enrich_with_github(), all_prs))
+        click.echo(json.dumps([pr.to_dict() for pr in all_prs], indent=2, default=str))
+        return
+
+    def build_grid():
+        grid = Table.grid(padding=(0, 1))
+        grid.add_column(no_wrap=True)  # state dot / spinner
+        grid.add_column(no_wrap=True)  # shortcut (linked)
+        grid.add_column(no_wrap=True, style="dim")  # patch marker
+        grid.add_column(no_wrap=True, overflow="ellipsis")  # title
+        grid.add_column(no_wrap=True, justify="right", style="dim")  # last updated
+        for pr in all_prs:
+            if not check:
+                state_cell, updated, title = "-", "", ""
+            elif not pr.is_enriched:
+                state_cell, updated, title = Spinner("dots"), "", ""
+            else:
+                state = "merged" if pr.merged else pr.state
+                state_cell = f"[{PR_STATE_STYLES.get(state, 'white')}]●[/]"
+                updated = arrow.get(pr.updated_at).humanize() if pr.updated_at else ""
+                title = pr.title or ""
+            grid.add_row(
+                state_cell,
+                f"[link={pr.url}]{pr.shortcut}[/link]",
+                "(patch)" if pr.is_patch else "",
+                title,
+                updated,
+            )
+        return grid
+
+    if check and all_prs:
+        with (
+            Live(build_grid(), console=console, refresh_per_second=10) as live,
+            ThreadPoolExecutor(max_workers=8) as pool,
+        ):
+            futures = [pool.submit(pr.enrich_with_github) for pr in all_prs]
+            for _ in as_completed(futures):
+                live.update(build_grid())
     else:
-        repositories = [pm_utils.Repo(repo_path) for repo_path in repo_paths]
-    for repo in repositories:
-        repo.show_prs(state=state, purge=purge, yes_all=yes_all)
+        console.print(build_grid())
+
+
+@cli.command(name="clean")
+@click.argument(
+    "repo_paths",
+    required=False,
+    nargs=-1,
+)
+@click.option(
+    "--aggregate/--no-aggregate",
+    "aggregate",
+    is_flag=True,
+    default=True,
+    help="Run git aggregate (and push) on each touched repo after purging",
+)
+def clean_pending(repo_paths=(), aggregate=True):
+    """Remove merged pull requests from pending-merge files."""
+    repos = _resolve_repos(repo_paths)
+    all_prs = [pr for repo in repos for pr in repo._iter_pending_pull_requests()]
+    if not all_prs:
+        return
+    touched_repos: set[pm_utils.Repo] = set()
+    removed: set[int] = set()  # ids of PRs removed from their merges file
+
+    def build_grid():
+        grid = Table.grid(padding=(0, 1))
+        grid.add_column(no_wrap=True)  # state dot / spinner
+        grid.add_column(no_wrap=True)  # shortcut (linked)
+        grid.add_column(no_wrap=True, style="dim")  # patch marker
+        grid.add_column(no_wrap=True)  # outcome
+        for pr in all_prs:
+            if not pr.is_enriched:
+                state_cell, outcome = Spinner("dots"), ""
+            else:
+                state = "merged" if pr.merged else pr.state
+                state_cell = f"[{PR_STATE_STYLES.get(state, 'white')}]●[/]"
+                outcome = "[green]removed[/]" if id(pr) in removed else ""
+            grid.add_row(
+                state_cell,
+                f"[link={pr.url}]{pr.shortcut}[/link]",
+                "(patch)" if pr.is_patch else "",
+                outcome,
+            )
+        return grid
+
+    # Enrich every PR via the GitHub API in parallel; remove the merged ones
+    # from the merges file as soon as we know the verdict, on the main thread
+    # (so concurrent yaml edits stay race-free).
+    with (
+        Live(build_grid(), console=console, refresh_per_second=10) as live,
+        ThreadPoolExecutor(max_workers=8) as pool,
+    ):
+        futures = {pool.submit(pr.enrich_with_github): pr for pr in all_prs}
+        for future in as_completed(futures):
+            future.result()
+            pr = futures[future]
+            if pr.merged:
+                if pr.is_patch:
+                    pr._repo.remove_pending_pull_from_patches(pr.owner, pr.pr)
+                else:
+                    pr._repo.remove_pending_pull(pr.owner, pr.pr)
+                touched_repos.add(pr._repo)
+                removed.add(id(pr))
+            live.update(build_grid())
+    # Per-repo post-processing: clean up an empty merges file or re-aggregate.
+    for repo in touched_repos:
+        if not repo.has_any_pr_left():
+            repo._handle_empty_merges_file(delete_file=True)
+        elif aggregate:
+            aggregator = repo.get_aggregator()
+            aggregator.aggregate()
+            aggregator.push()
 
 
 # TODO: add tests

--- a/odoo_tools/cli/pending.py
+++ b/odoo_tools/cli/pending.py
@@ -25,10 +25,10 @@ def cli():
     pass
 
 
-def _resolve_repos(repo_paths):
+def _resolve_repos(repo_paths, path_check=True):
     if not repo_paths:
-        return pm_utils.Repo.repositories_from_pending_folder()
-    return [pm_utils.Repo(repo_path) for repo_path in repo_paths]
+        return pm_utils.Repo.repositories_from_pending_folder(path_check=path_check)
+    return [pm_utils.Repo(repo_path, path_check=path_check) for repo_path in repo_paths]
 
 
 @cli.command(name="show")
@@ -58,7 +58,7 @@ def _resolve_repos(repo_paths):
 )
 def show_pending(repo_paths=(), check=True, as_json=False):
     """List pull requests on <repo_path>."""
-    repos = _resolve_repos(repo_paths)
+    repos = _resolve_repos(repo_paths, path_check=False)
     all_prs = [pr for repo in repos for pr in repo._iter_pending_pull_requests()]
     # In case of --json, output directly
     if as_json:

--- a/odoo_tools/cli/submodule.py
+++ b/odoo_tools/cli/submodule.py
@@ -165,7 +165,10 @@ def upgrade(submodule_path, force_branch):
             repo = pm_utils.Repo(submodule.path, path_check=False)
             if repo.has_pending_merges():
                 ui.echo(f"Purging merged PRs for {submodule.path}")
-                repo.show_prs(purge="merged", yes_all=True)
+                for pr in repo.purge_merged_prs():
+                    ui.echo(f"  removed {pr.shortcut}")
+                if not repo.has_any_pr_left():
+                    repo._handle_empty_merges_file(delete_file=True)
             if repo.has_pending_merges():
                 ui.echo(f"Rebuilding consolidation branch for {submodule.path}")
                 repo.rebuild_consolidation_branch(push=True)

--- a/odoo_tools/utils/click.py
+++ b/odoo_tools/utils/click.py
@@ -8,12 +8,45 @@ from .minimum_version import with_minimum_version_check
 from .update_check import with_update_check
 
 __all__ = [
+    "deprecated_option",
     "handle_exceptions",
     "global_command_decorators",
     "version_option",
     "with_minimum_version_check",
     "with_update_check",
 ]
+
+
+def deprecated_option(*param_decls, message: str | None = None, **kwargs):
+    """``click.option`` variant that rejects use with a deprecation message.
+
+    The option is hidden from ``--help``, accepts no value, and exits with
+    a friendly error pointing the user at the replacement.
+
+    Usage:
+
+    .. code-block:: python
+
+        @deprecated_option("--purge", message="Use `... clean` instead.")
+        def show_pending(...):
+            ...
+    """
+
+    def callback(ctx, param, value):
+        if value:
+            raise click.BadOptionUsage(
+                param.opts[0],
+                message or f"`{param.opts[0]}` has been removed.",
+                ctx=ctx,
+            )
+
+    kwargs.setdefault("is_flag", True)
+    kwargs.setdefault("default", False)
+    kwargs["hidden"] = True
+    kwargs["expose_value"] = False
+    kwargs["callback"] = callback
+    return click.option(*param_decls, **kwargs)
+
 
 version_option = click.version_option(
     __version__, "-V", "--version", package_name="odoo-tools"

--- a/odoo_tools/utils/gh.py
+++ b/odoo_tools/utils/gh.py
@@ -9,6 +9,29 @@ from . import ui
 from .os_exec import run
 from .proj import get_project_manifest_key
 
+RE_GH_REMOTE_URL = re.compile(
+    r"^(?:https?://github\.com/|git@github\.com:)"
+    r"(?P<owner>[^/]+)/(?P<repo>[^/]+?)(?:\.git)?$"
+)
+
+
+def parse_remote_url(url: str) -> tuple[str, str]:
+    """Parse a github remote URL and return ``(owner, repo)``.
+
+    Supports both ``git@github.com:OWNER/repo.git`` and
+    ``https://github.com/OWNER/repo`` forms (the ``.git`` suffix is
+    optional).
+
+    :raises ValueError: when ``url`` is empty or does not match a github
+        remote URL.
+    """
+    if not url:
+        raise ValueError("empty remote URL")
+    match = RE_GH_REMOTE_URL.match(str(url))
+    if not match:
+        raise ValueError(f"Invalid github remote URL: {url}")
+    return match.group("owner"), match.group("repo")
+
 
 def parse_github_url(entity_spec):
     # "entity" is either a PR, commit or a branch

--- a/odoo_tools/utils/pending_merge.py
+++ b/odoo_tools/utils/pending_merge.py
@@ -2,6 +2,10 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 
 import logging
+import os
+import re
+from collections.abc import Iterator
+from dataclasses import dataclass, field
 from pathlib import Path
 
 import click
@@ -20,7 +24,92 @@ from .path import build_path, cd
 from .proj import get_current_version, get_project_manifest_key
 from .yaml import yaml_dump, yaml_load
 
+logger = logging.getLogger(__name__)
+
 git_aggregator.main.setup_logger()
+
+
+@dataclass(kw_only=True)
+class PendingPR:
+    """A pending-merge pull request, derived from the local merges file.
+
+    The fields below ``is_patch`` are populated by
+    :meth:`enrich_with_github`; until then ``state`` is ``None``.
+    """
+
+    _repo: "Repo"
+    owner: str
+    pr: int
+    is_patch: bool
+    # GitHub repo name; can differ from the local submodule directory name
+    # (``self._repo.name``). Defaults to it when unspecified.
+    repo: str | None = None
+    # Filled in by enrich_with_github(); ``state is None`` means not yet enriched.
+    state: str | None = None
+    merged: bool = False
+    labels: list[str] = field(default_factory=list)
+    number: int | None = None
+    title: str | None = None
+    updated_at: str | None = None
+
+    def __post_init__(self):
+        if self.repo is None:
+            self.repo = self._repo.name
+
+    @property
+    def shortcut(self) -> str:
+        return f"{self.owner}/{self.repo}#{self.pr}"
+
+    @property
+    def url(self) -> str:
+        return f"https://github.com/{self.owner}/{self.repo}/pull/{self.pr}"
+
+    @property
+    def is_enriched(self) -> bool:
+        return self.state is not None
+
+    def to_dict(self) -> dict:
+        """Return a JSON-friendly dict (with computed properties)."""
+        return {
+            "repo": self.repo,
+            "owner": self.owner,
+            "pr": self.pr,
+            "is_patch": self.is_patch,
+            "state": self.state,
+            "merged": self.merged,
+            "labels": self.labels,
+            "number": self.number,
+            "title": self.title,
+            "updated_at": self.updated_at,
+            "shortcut": self.shortcut,
+            "url": self.url,
+        }
+
+    def enrich_with_github(self) -> None:
+        """Fetch the PR's GitHub state and update this instance in place."""
+        api_url = (
+            f"https://api.github.com/repos/{self.owner}/{self.repo}/pulls/{self.pr}"
+        )
+        headers = {}
+        if token := os.environ.get("GITHUB_TOKEN"):
+            headers["Authorization"] = f"token {token}"
+        response = requests.get(api_url, headers=headers)
+        if not response.ok:
+            logger.warning(
+                "Could not get status of %s: %s %s",
+                self.shortcut,
+                response.status_code,
+                response.reason,
+            )
+            self.state = ""
+            return
+        data = response.json()
+        self.state = data.get("state") or ""
+        self.merged = bool(data.get("merged"))
+        self.labels = [label["name"] for label in data.get("labels") or []]
+        self.number = data.get("number")
+        self.title = data.get("title")
+        self.updated_at = data.get("updated_at")
 
 
 class Repo:
@@ -406,143 +495,66 @@ class Repo:
             extra_config["target"]["remote"] = target_remote
         return RepoAggregator(self, **extra_config)
 
-    # TODO: add tests
-    def show_prs(self, state=None, purge=None, yes_all=False):
-        """Show all pull requests in pending merges.
+    def _iter_pending_pull_requests(self) -> Iterator[PendingPR]:
+        merges_config = self.merges_config()
+        if not merges_config:
+            return
+        remotes = merges_config.get("remotes") or {}
+        # Skip the first ``merges`` entry, which is the base ref (e.g. ``OCA 16.0``)
+        for merge_line in list(merges_config.get("merges") or [])[1:]:
+            parts = str(merge_line).split()
+            if len(parts) != 2:
+                continue
+            remote, ref = parts
+            pull_match = re.match(r"^(?:refs/)?pull/(\d+)/head$", ref)
+            if not pull_match:
+                continue
+            try:
+                owner, github_repo = gh.parse_remote_url(remotes.get(remote, ""))
+            except ValueError:
+                owner = remote
+                github_repo = self.name
+            yield PendingPR(
+                _repo=self,
+                owner=owner,
+                repo=github_repo,
+                pr=int(pull_match.group(1)),
+                is_patch=False,
+            )
+        for line in merges_config.get("shell_command_after") or []:
+            if ".patch" not in line or "git am" not in line:
+                continue
+            url = line.split(".patch")[0]
+            try:
+                info = gh.parse_github_url(url)
+            except ValueError:
+                continue
+            yield PendingPR(
+                _repo=self,
+                owner=info["upstream"],
+                repo=info["repo_name"],
+                pr=int(info["entity_id"]),
+                is_patch=True,
+            )
 
-        :param state: list only matching states
-        :param purge: purge matching states
+    def purge_merged_prs(self) -> Iterator[PendingPR]:
+        """Remove merged pull requests from the pending-merges file.
+
+        Iterates the local pending-merges, enriches each one via the GitHub
+        API, and yields the merged ones as soon as they are removed so that
+        callers can report progress in real time.
         """
-        if purge:
-            assert purge in ("closed", "merged")
-        logging.getLogger("requests").setLevel(logging.ERROR)
-
-        # NOTE: to collect all this info you must provide your GITHUB_TOKEN.
-        # See git-aggregator README.
-        pr_info_msg = (
-            "#{number} {title}\n"
-            "      State: {state} ({merged})\n"
-            "      Updated at: {updated_at}\n"
-            "      View: {html_url}\n"
-            "      Shortcut: {shortcut}\n"
-        )
-        all_repos_prs = {}
-        ui.echo("--")
-        ui.echo(f"Checking: {self.name}")
-        ui.echo(f"Path: {self.path}")
-        ui.echo(f"Merge file: {self.merges_path}")
-
-        all_prs = self._collect_prs()
-
-        if state is not None:
-            if state == "merged":
-                all_prs = {"closed": all_prs.get("closed", [])}
-                all_prs["closed"] = [
-                    pr for pr in all_prs["closed"] if pr.get("merged") == "merged"
-                ]
+        for pr in self._iter_pending_pull_requests():
+            pr.enrich_with_github()
+            if not pr.merged:
+                continue
+            if pr.is_patch:
+                self.remove_pending_pull_from_patches(pr.owner, pr.pr)
             else:
-                all_prs = {k: v for k, v in all_prs.items() if k == state}
-        for pr_state, prs in all_prs.items():
-            ui.echo(f"State: {pr_state}")
-            for i, pr_info in enumerate(prs, 1):
-                all_repos_prs.setdefault(pr_state, []).append(pr_info)
-                pr_info["raw"].update(pr_info)
-                nr = str(i).zfill(2)
-                pr = pr_info_msg.format(**pr_info["raw"])
-                ui.echo(f"  {nr}) {pr}")
-
-        purged = None
-        if purge and all_repos_prs.get("closed", []):
-            kw = {f"purge_{purge}": True}
-            purged = self._purge_closed_prs(all_repos_prs, **kw)
-
-        if purged and self.has_pending_merges():
-            if yes_all or ui.ask_confirmation("Do you want to re-aggregate and push?"):
-                aggregator = self.get_aggregator()
-                aggregator.aggregate()
-                aggregator.push()
+                self.remove_pending_pull(pr.owner, pr.pr)
+            yield pr
         if not self.has_any_pr_left():
-            self._handle_empty_merges_file(delete_file=yes_all)
-        return all_repos_prs
-
-    def _collect_prs(self):
-        aggregator = self.get_aggregator()
-        # Normal merges
-        all_prs = aggregator.collect_prs_info()
-        # patches
-        patch_merges = []
-        # Convert lines like:
-        # "curl -sSL https://github.com/OCA/manufacture/pull/1469.patch
-        # | git am -3 --keep-non-patch --exclude '*requirements.txt'"
-        # ...to...
-        # OCA refs/pull/1469/head
-        patches = self.merges_config().get("shell_command_after") or []
-        if not patches:
-            return all_prs
-        for line in patches:
-            if ".patch" in line and "git am" in line:
-                line = line.split(".patch")[0]
-                pr_info = gh.parse_github_url(line)
-                patch_merges.append(
-                    {
-                        "remote": pr_info["upstream"],
-                        "ref": f"refs/{pr_info['entity_type']}/{pr_info['entity_id']}/head",
-                    }
-                )
-        patch_merges = aggregator.collect_prs_info(merges=patch_merges)
-        for state, prs in patch_merges.items():
-            for pr_info in prs:
-                pr_info["_patch"] = True
-            all_prs.setdefault(state, []).extend(prs)
-        return all_prs
-
-    # TODO: add tests
-    def _purge_closed_prs(self, all_repos_prs, purge_merged=False, purge_closed=False):
-        assert purge_closed or purge_merged
-        closed_prs = all_repos_prs.get("closed", [])
-        closed_unmerged_prs = [
-            pr for pr in closed_prs if pr.get("merged") == "not merged"
-        ]
-        closed_merged_prs = [pr for pr in closed_prs if pr.get("merged") == "merged"]
-
-        # This list will receive all closed and unmerged pr's url to return
-        # If purge_closed is set to True, removed prs will not be returned
-        unmerged_prs_urls = [pr.get("url") for pr in closed_unmerged_prs]
-
-        purged = False
-        if closed_unmerged_prs and purge_closed:
-            ui.echo("Purging closed ones...")
-            for closed_pr_info in closed_unmerged_prs:
-                try:
-                    if closed_pr_info.get("_patch"):
-                        self.remove_pending_pull_from_patches(
-                            closed_pr_info["owner"], closed_pr_info["pr"]
-                        )
-                    else:
-                        self.remove_pending_pull(
-                            closed_pr_info["owner"], closed_pr_info["pr"]
-                        )
-                    unmerged_prs_urls.remove(closed_pr_info.get("url"))
-                    purged = True
-                except Exception as e:
-                    ui.echo(
-                        "An error occurs during '{}' removal : {}".format(
-                            closed_pr_info.get("url"), e
-                        )
-                    )
-        if closed_merged_prs and purge_merged:
-            ui.echo("Purging merged ones...")
-            for closed_pr_info in closed_merged_prs:
-                if closed_pr_info.get("_patch"):
-                    self.remove_pending_pull_from_patches(
-                        closed_pr_info["owner"], closed_pr_info["pr"]
-                    )
-                else:
-                    self.remove_pending_pull(
-                        closed_pr_info["owner"], closed_pr_info["pr"]
-                    )
-                purged = True
-        return purged
+            self._handle_empty_merges_file(delete_file=True)
 
     def _handle_empty_merges_file(self, delete_file=False):
         odoo_version = get_project_manifest_key("odoo_version")

--- a/odoo_tools/utils/pending_merge.py
+++ b/odoo_tools/utils/pending_merge.py
@@ -171,10 +171,10 @@ class Repo:
         return (base_path / repo_name).with_suffix(".yml")
 
     @classmethod
-    def repositories_from_pending_folder(cls, path=None):
+    def repositories_from_pending_folder(cls, path=None, path_check=True):
         pending_merge_abs_path = build_path(config.pending_merge_rel_path)
         path = Path(path or pending_merge_abs_path)
-        return [cls(pth.stem) for pth in path.rglob("*.yml")]
+        return [cls(pth.stem, path_check=path_check) for pth in path.rglob("*.yml")]
 
     def has_pending_merges(self):
         # either empty or commented out

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ classifiers = [
     "Natural Language :: English",
 ]
 dependencies = [
+    "arrow",
     "requests==2.33.1",
     "git-aggregator>=4.1",
     "git-autoshare",

--- a/tests/test_submodule.py
+++ b/tests/test_submodule.py
@@ -325,7 +325,14 @@ def test_upgrade_with_pending_merges(project):
             "has_pending_merges",
             return_value=True,
         ),
-        mock.patch.object(submodule.pm_utils.Repo, "show_prs") as mock_show_prs,
+        mock.patch.object(
+            submodule.pm_utils.Repo,
+            "has_any_pr_left",
+            return_value=True,
+        ),
+        mock.patch.object(
+            submodule.pm_utils.Repo, "purge_merged_prs", return_value=[]
+        ) as mock_purge,
         mock.patch.object(
             submodule.pm_utils.Repo, "rebuild_consolidation_branch"
         ) as mock_rebuild,
@@ -336,7 +343,7 @@ def test_upgrade_with_pending_merges(project):
             catch_exceptions=False,
         )
     assert result.exit_code == 0
-    mock_show_prs.assert_called_once_with(purge="merged", yes_all=True)
+    mock_purge.assert_called_once_with()
     mock_rebuild.assert_called_once_with(push=True)
 
 

--- a/tests/test_utils_gh.py
+++ b/tests/test_utils_gh.py
@@ -156,6 +156,34 @@ class TestGetTargetBranch:
             mock_ask.assert_called_once()
 
 
+class TestParseRemoteUrl:
+    @pytest.mark.parametrize(
+        "url, expected",
+        [
+            ("git@github.com:OCA/edi.git", ("OCA", "edi")),
+            ("git@github.com:OCA/edi", ("OCA", "edi")),
+            ("https://github.com/OCA/edi.git", ("OCA", "edi")),
+            ("https://github.com/OCA/edi", ("OCA", "edi")),
+            ("http://github.com/OCA/edi.git", ("OCA", "edi")),
+        ],
+    )
+    def test_valid(self, url, expected):
+        assert gh_utils.parse_remote_url(url) == expected
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "",
+            "git@gitlab.com:OCA/edi.git",
+            "https://example.com/OCA/edi",
+            "OCA/edi",
+        ],
+    )
+    def test_invalid_raises(self, url):
+        with pytest.raises(ValueError):
+            gh_utils.parse_remote_url(url)
+
+
 @pytest.mark.project_setup(git_init=True)
 @pytest.mark.usefixtures("project")
 class TestCheckGitDiff:

--- a/tests/test_utils_pending_merge.py
+++ b/tests/test_utils_pending_merge.py
@@ -2,9 +2,11 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 
 from pathlib import Path
+from textwrap import dedent
 from unittest import mock
 
 import pytest
+import responses
 from git.config import GitConfigParser
 
 from odoo_tools.exceptions import Exit, PathNotFound
@@ -620,3 +622,204 @@ def test_add_pending_pull_request_patch():
     line_tmpl = "curl -sSL https://github.com/OCA/edi/pull/{}.patch | git am -3 --keep-non-patch --exclude '*requirements.txt'"
     for pid in (1470, 1471):
         assert line_tmpl.format(pid) in shell_command_after, shell_command_after
+
+
+def test_iter_pending_pull_requests(project):
+    name = "edi"
+    mock_pending_merge_repo_paths(
+        name,
+        tmpl=dedent(
+            """
+            ../{ext_src_rel_path}/{repo_name}:
+                remotes:
+                    camptocamp: git@github.com:camptocamp/{repo_name}.git
+                    {org_name}: git@github.com:{org_name}/{repo_name}.git
+                target: camptocamp merge-branch-{pid}-master
+                merges:
+                - {org_name} 14.0
+                - {org_name} refs/pull/774/head
+                - {org_name} refs/pull/773/head
+                shell_command_after:
+                - curl -sSL https://github.com/OCA/edi/pull/999.patch | git am -3 --keep-non-patch --exclude '*requirements.txt'
+            """
+        ),
+    )
+    repo = Repo(name)
+    prs = list(repo._iter_pending_pull_requests())
+    # 2 merges (the base ``OCA 14.0`` is skipped) + 1 patch
+    assert len(prs) == 3
+    pulls = [pr for pr in prs if not pr.is_patch]
+    patches = [pr for pr in prs if pr.is_patch]
+    assert sorted(pr.pr for pr in pulls) == [773, 774]
+    assert [pr.pr for pr in patches] == [999]
+    pr = pulls[0]
+    assert pr._repo is repo
+    assert pr.repo == "edi"
+    assert pr.owner == "OCA"
+    assert pr.shortcut.startswith("OCA/edi#")
+    assert pr.url.startswith("https://github.com/OCA/edi/pull/")
+    assert isinstance(pr, pm_utils.PendingPR)
+    assert pr.is_enriched is False
+
+
+@pytest.mark.project_setup(proj_tmpl_ver=1)
+def test_iter_pending_pull_requests_with_mismatched_github_repo(project):
+    """The submodule directory name and the GitHub repo name don't always match.
+
+    Real-world example: the ``src`` submodule (checked out under ``odoo/src``)
+    pulls a base merge from ``OCA/OCB`` and patches from ``odoo/odoo`` —
+    neither of those GitHub repos is named ``src``.
+    """
+    mock_pending_merge_repo_paths(
+        "src",
+        tmpl=dedent(
+            """
+            ../odoo/src:
+              remotes:
+                camptocamp: git@github.com:camptocamp/odoo.git
+                oca: git@github.com:OCA/OCB.git
+                odoo: git@github.com:odoo/odoo.git
+              target: camptocamp merge-branch-{pid}-master
+              merges:
+              - oca 17.0
+              - oca refs/pull/100/head
+              shell_command_after:
+              - curl -sSL https://github.com/odoo/odoo/pull/215486.patch | git am -3
+            """
+        ),
+    )
+    repo = Repo("src")
+    prs = list(repo._iter_pending_pull_requests())
+    assert len(prs) == 2
+    merge_pr = next(pr for pr in prs if not pr.is_patch)
+    patch_pr = next(pr for pr in prs if pr.is_patch)
+    # Submodule directory is ``src``, but the GitHub repo is ``OCB``.
+    assert merge_pr._repo.name == "src"
+    assert merge_pr.owner == "OCA"
+    assert merge_pr.repo == "OCB"
+    assert merge_pr.shortcut == "OCA/OCB#100"
+    assert merge_pr.url == "https://github.com/OCA/OCB/pull/100"
+    # Patch entry resolves owner+repo from the patch URL itself.
+    assert patch_pr.owner == "odoo"
+    assert patch_pr.repo == "odoo"
+    assert patch_pr.shortcut == "odoo/odoo#215486"
+    assert patch_pr.url == "https://github.com/odoo/odoo/pull/215486"
+
+
+def _fake_enrich(pr_states):
+    """Build a side_effect that mutates a ``PendingPR`` in place.
+
+    :param pr_states: mapping of PR number -> ``(state, merged)`` tuple.
+    """
+
+    def enrich(self):
+        state, merged = pr_states.get(self.pr, ("open", False))
+        self.state = state
+        self.merged = merged
+        self.title = f"PR {self.pr}"
+        self.number = self.pr
+
+    return enrich
+
+
+def test_purge_merged_prs(project):
+    name = "edi"
+    mock_pending_merge_repo_paths(name)
+    repo = Repo(name)
+    pr_states = {
+        774: ("open", False),
+        773: ("closed", True),
+        759: ("closed", False),
+    }
+    with mock.patch.object(
+        pm_utils.PendingPR,
+        "enrich_with_github",
+        autospec=True,
+        side_effect=_fake_enrich(pr_states),
+    ):
+        # Materialize within the patch context: ``purge_merged_prs`` is a
+        # generator, so the API calls only happen as we iterate.
+        purged = list(repo.purge_merged_prs())
+    # Only the merged one is removed
+    assert [pr.pr for pr in purged] == [773]
+    remaining = repo.merges_config()["merges"]
+    # base (OCA 14.0) + 774 + 663 + 759 stay; 773 is gone
+    assert "OCA refs/pull/773/head" not in remaining
+    assert "OCA refs/pull/774/head" in remaining
+    assert "OCA refs/pull/759/head" in remaining
+
+
+def _make_pending(repo, pr_id):
+    return pm_utils.PendingPR(
+        _repo=repo,
+        owner="OCA",
+        pr=pr_id,
+        is_patch=False,
+    )
+
+
+def test_enrich_with_github(project):
+    name = "edi"
+    mock_pending_merge_repo_paths(name)
+    repo = Repo(name)
+    pending = _make_pending(repo, 773)
+    with responses.RequestsMock() as rsps:
+        rsps.add(
+            responses.GET,
+            "https://api.github.com/repos/OCA/edi/pulls/773",
+            json={
+                "state": "closed",
+                "merged": True,
+                "number": 773,
+                "title": "A merged PR",
+                "updated_at": "2025-01-02T00:00:00Z",
+                "labels": [{"name": "bug"}, {"name": "16.0"}],
+            },
+            status=200,
+        )
+        pending.enrich_with_github()
+    assert pending.is_enriched
+    assert pending.state == "closed"
+    assert pending.merged is True
+    assert pending.title == "A merged PR"
+    assert pending.labels == ["bug", "16.0"]
+    # Locally-derivable fields are unchanged
+    assert pending._repo is repo
+    assert pending.repo == "edi"
+    assert pending.is_patch is False
+
+
+def test_enrich_with_github_api_error(project):
+    name = "edi"
+    mock_pending_merge_repo_paths(name)
+    repo = Repo(name)
+    pending = _make_pending(repo, 9999)
+    with responses.RequestsMock() as rsps:
+        rsps.add(
+            responses.GET,
+            "https://api.github.com/repos/OCA/edi/pulls/9999",
+            status=404,
+        )
+        pending.enrich_with_github()
+    # Empty state on API failure means purge_merged_prs won't touch it
+    assert pending.is_enriched
+    assert pending.state == ""
+    assert pending.merged is False
+
+
+def test_enrich_with_github_uses_token(project, monkeypatch):
+    name = "edi"
+    mock_pending_merge_repo_paths(name)
+    repo = Repo(name)
+    pending = _make_pending(repo, 773)
+    monkeypatch.setenv("GITHUB_TOKEN", "secret-token")
+    with responses.RequestsMock() as rsps:
+        rsps.add(
+            responses.GET,
+            "https://api.github.com/repos/OCA/edi/pulls/773",
+            json={"state": "open", "merged": False},
+            status=200,
+        )
+        pending.enrich_with_github()
+        sent = list(rsps.calls)
+        assert sent[0].request.headers.get("Authorization") == "token secret-token"

--- a/uv.lock
+++ b/uv.lock
@@ -656,6 +656,7 @@ wheels = [
 name = "odoo-tools"
 source = { editable = "." }
 dependencies = [
+    { name = "arrow" },
     { name = "bump-my-version" },
     { name = "click" },
     { name = "clipboard" },
@@ -690,6 +691,7 @@ test = [
 
 [package.metadata]
 requires-dist = [
+    { name = "arrow" },
     { name = "bump-my-version" },
     { name = "click", specifier = ">=8.3.2" },
     { name = "clipboard" },


### PR DESCRIPTION
Final goal is to be able to generate a report that updates a github issue in a repository through a gh action, like: https://github.com/camptocamp/allchemet_odoo/issues/37

For that to happen we need:
- a command that list all PRs without checking their state through gh api
- a machine-readable output

**What this PR does:**

Changes in `show` command:
- Removed `--purge` option. Use `clean` command instead.
- Removed `--state` option. If needed, use --json with jq filters.
- Added `--check` / `--no-check` options. If not checking, the command with show the pending merges without checking their status via the GitHub API.
- Added `--json` option. If specified, the command will output the pending PRs as a JSON array.
- Concurrently fetch from API to speed up the command.

Added a new `clean` command:
- Removes merged PRs from pending merges files.

**Being tested in Allchemet**:
- https://github.com/camptocamp/allchemet_odoo/blob/master/.github/workflows/pending-merges-report.yml

**Examples:**

https://github.com/user-attachments/assets/acb8dc9f-fc63-4643-82df-5abd8f1ee9c0

https://github.com/user-attachments/assets/c6addf47-3cba-46e1-bd77-19611748e2d9

https://github.com/user-attachments/assets/78b159f4-3941-4fca-85a5-a4ea0e790c46

https://github.com/user-attachments/assets/b9e31717-a51d-43f7-a7e8-3b7c82337f50

https://github.com/user-attachments/assets/9307e493-5381-4252-b669-1ae0d85d2fe9

https://github.com/user-attachments/assets/7d817da9-9e1c-46e3-9b7d-22bbb42ccfda