### PR TITLE
[ADD] cli: add support for API token in dump list and download commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,18 @@ otools-cloud dump download --env prod --name celebrimbor-database-name.pg.gpg --
 otools-cloud dump upload --from-db odoodb --env labs.my-lab
 ```
 
+##### List dumps with an explicit API token
+
+```
+otools-cloud dump list --env prod --token "$CELEBRIMBOR_TOKEN"
+```
+
+##### Download a specific dump with an explicit API token
+
+```
+otools-cloud dump download --env prod --name celebrimbor-database-name.pg.gpg --token "$CELEBRIMBOR_TOKEN"
+```
+
 ### otools-i18n
 
 Tools to manage internationalization (i18n).

--- a/odoo_tools/cli/cloud.py
+++ b/odoo_tools/cli/cloud.py
@@ -23,17 +23,32 @@ def build_celebrimbor_command(command, platform=None, customer=None, env="int", 
     if customer is None:
         project = utils.proj.get_project_manifest_key("project_name")
         customer = get_customer_name_from_project_name(project)
-    return [
-        "celebrimbor_cli",
-        "--platform",
-        platform,
-        command,
-        "--customer",
-        customer,
-        "--env",
-        env,
-        *args,
-    ]
+    command_args = ["celebrimbor_cli"]
+    extra_args = [*args]
+
+    # celebrimbor_cli expects --token before the command name.
+    if "--token" in extra_args:
+        token_index = extra_args.index("--token")
+        try:
+            token = extra_args[token_index + 1]
+        except IndexError as err:
+            raise click.UsageError("Token value is missing after --token") from err
+        extra_args = extra_args[:token_index] + extra_args[token_index + 2 :]
+        command_args.extend(["--token", token])
+
+    command_args.extend(
+        [
+            "--platform",
+            platform,
+            command,
+            "--customer",
+            customer,
+            "--env",
+            env,
+            *extra_args,
+        ]
+    )
+    return command_args
 
 
 def run_celebrimbor(
@@ -103,8 +118,16 @@ def common_celebrimbor_options(func):
     "--restore-to-db",
     help="If provided, the dump will be restored to this local database after download",
 )
+@click.option("--token", help="Token to access the cloud platform API", default=None)
 @utils.click.handle_exceptions()
-def download(platform=None, customer=None, env="prod", name=None, restore_to_db=None):
+def download(
+    platform=None,
+    customer=None,
+    env="prod",
+    name=None,
+    restore_to_db=None,
+    token=None,
+):
     """Download a dump from the cloud platform."""
     # We only need it for the restore, so that we know exactly the downloaded file
     if name is None and restore_to_db is not None:
@@ -116,6 +139,8 @@ def download(platform=None, customer=None, env="prod", name=None, restore_to_db=
     extra_args = []
     if name is not None:
         extra_args.extend(["--name", name])
+    if token is not None:
+        extra_args.extend(["--token", token])
     run_celebrimbor("download", platform, customer, env, *extra_args)
     # Restore if requested
     if restore_to_db:
@@ -171,10 +196,12 @@ def restore(dump_name, platform, customer, env, from_prod):
 
 @dump.command()
 @common_celebrimbor_options
+@click.option("--token", help="Token to access the cloud platform API", default=None)
 @utils.click.handle_exceptions()
-def list(platform, customer, env):
+def list(platform, customer, env, token):
     """List available dumps on the cloud platform."""
-    run_celebrimbor("list", platform, customer, env)
+    extra_args = ["--token", token] if token else []
+    run_celebrimbor("list", platform, customer, env, *extra_args)
 
 
 if __name__ == "__main__":

--- a/odoo_tools/cli/cloud.py
+++ b/odoo_tools/cli/cloud.py
@@ -16,7 +16,9 @@ def get_customer_name_from_project_name(project_name: str) -> str:
     return "-".join(project_name.split("_")[:-1])
 
 
-def build_celebrimbor_command(command, platform=None, customer=None, env="int", *args):
+def build_celebrimbor_command(
+    command, platform=None, customer=None, env="int", token=None, *args
+):
     """Build celebrimbor_cli command."""
     if platform is None:
         platform = utils.proj.get_project_manifest_key("country")
@@ -27,13 +29,7 @@ def build_celebrimbor_command(command, platform=None, customer=None, env="int", 
     extra_args = [*args]
 
     # celebrimbor_cli expects --token before the command name.
-    if "--token" in extra_args:
-        token_index = extra_args.index("--token")
-        try:
-            token = extra_args[token_index + 1]
-        except IndexError as err:
-            raise click.UsageError("Token value is missing after --token") from err
-        extra_args = extra_args[:token_index] + extra_args[token_index + 2 :]
+    if token is not None:
         command_args.extend(["--token", token])
 
     command_args.extend(
@@ -52,7 +48,13 @@ def build_celebrimbor_command(command, platform=None, customer=None, env="int", 
 
 
 def run_celebrimbor(
-    command, platform=None, customer=None, env="int", *extra_args, **subprocess_kwargs
+    command,
+    platform=None,
+    customer=None,
+    env="int",
+    *extra_args,
+    token=None,
+    **subprocess_kwargs,
 ):
     """Run celebrimbor_cli with default values from project manifest."""
     if not utils.os_exec.has_exec("celebrimbor_cli"):
@@ -64,7 +66,7 @@ def run_celebrimbor(
         )
         return
     return subprocess.run(
-        build_celebrimbor_command(command, platform, customer, env, *extra_args),
+        build_celebrimbor_command(command, platform, customer, env, token, *extra_args),
         env=utils.os_exec.get_venv(),
         check=True,
         **subprocess_kwargs,
@@ -139,9 +141,7 @@ def download(
     extra_args = []
     if name is not None:
         extra_args.extend(["--name", name])
-    if token is not None:
-        extra_args.extend(["--token", token])
-    run_celebrimbor("download", platform, customer, env, *extra_args)
+    run_celebrimbor("download", platform, customer, env, *extra_args, token=token)
     # Restore if requested
     if restore_to_db:
         dump_path = Path(name.removesuffix(".gpg"))
@@ -200,8 +200,7 @@ def restore(dump_name, platform, customer, env, from_prod):
 @utils.click.handle_exceptions()
 def list(platform, customer, env, token):
     """List available dumps on the cloud platform."""
-    extra_args = ["--token", token] if token else []
-    run_celebrimbor("list", platform, customer, env, *extra_args)
+    run_celebrimbor("list", platform, customer, env, token=token)
 
 
 if __name__ == "__main__":

--- a/tests/test_cloud.py
+++ b/tests/test_cloud.py
@@ -459,3 +459,71 @@ def test_dump_list(project):
         )
         assert result.exit_code == 0
         mock_fn.assert_completed_calls()
+
+
+def test_dump_list_with_token(project):
+    """Test dump list command with API token."""
+    mock_fn = MockSubprocessRun(
+        [
+            {
+                "args": [
+                    "celebrimbor_cli",
+                    "--token",
+                    "my-token",
+                    "--platform",
+                    "ch",
+                    "list",
+                    "--customer",
+                    "acme",
+                    "--env",
+                    "int",
+                ],
+            }
+        ]
+    )
+
+    with (
+        mock.patch("odoo_tools.cli.cloud.utils.os_exec.has_exec", return_value=True),
+        mock.patch("subprocess.run", mock_fn),
+    ):
+        result = project.invoke(
+            cloud_cli,
+            ["dump", "list", "--token", "my-token"],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0
+        mock_fn.assert_completed_calls()
+
+
+def test_dump_download_with_token(project):
+    """Test dump download command with API token."""
+    mock_fn = MockSubprocessRun(
+        [
+            {
+                "args": [
+                    "celebrimbor_cli",
+                    "--token",
+                    "my-token",
+                    "--platform",
+                    "ch",
+                    "download",
+                    "--customer",
+                    "acme",
+                    "--env",
+                    "int",
+                ],
+            }
+        ]
+    )
+
+    with (
+        mock.patch("odoo_tools.cli.cloud.utils.os_exec.has_exec", return_value=True),
+        mock.patch("subprocess.run", mock_fn),
+    ):
+        result = project.invoke(
+            cloud_cli,
+            ["dump", "download", "--token", "my-token"],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0
+        mock_fn.assert_completed_calls()


### PR DESCRIPTION
This PR adds token support to cloud dump commands in the CLI.

It introduces --token support for **dump list** and **dump download**. The main challenge was building the command arguments, as the token needs to be passed before the command verb when using celebrimbor_cli.

This makes the `*args` parameter in the `build_celebrimbor_command` method effectively useless.