### PR TITLE
[ADD] labeler: add rules for cloud, db, i18n and password cli modules

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -53,6 +53,29 @@
       - any-glob-to-any-file:
           - 'odoo_tools/cli/migrate_db.py'
 
+"tool:cloud":
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'odoo_tools/cli/cloud.py'
+          - 'tests/test_cloud.py'
+
+"tool:db":
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'odoo_tools/cli/db.py'
+          - 'tests/test_db_*.py'
+
+"tool:i18n":
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'odoo_tools/cli/i18n.py'
+
+"tool:password":
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'odoo_tools/cli/password.py'
+          - 'tests/test_password.py'
+
 documentation:
   - changed-files:
       - any-glob-to-any-file:


### PR DESCRIPTION
These CLI modules had no labeler rule, so PRs touching them (e.g. cloud) got no code label and only picked up documentation/ci labels.