### PR TITLE
[FIX] pending: preserve correct comments when purging merged PRs

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -32,6 +32,8 @@
   - changed-files:
       - any-glob-to-any-file:
           - 'odoo_tools/cli/pending.py'
+          - 'odoo_tools/utils/pending_merge.py'
+          - 'tests/test_utils_pending_merge.py'
 
 "tool:conversion":
   - changed-files:

--- a/odoo_tools/utils/pending_merge.py
+++ b/odoo_tools/utils/pending_merge.py
@@ -22,7 +22,7 @@ from .config import config
 from .os_exec import run
 from .path import build_path, cd
 from .proj import get_current_version, get_project_manifest_key
-from .yaml import yaml_dump, yaml_load
+from .yaml import remove_seq_item_with_comments, yaml_dump, yaml_load
 
 logger = logging.getLogger(__name__)
 
@@ -443,7 +443,7 @@ class Repo:
             )
         for line in lines_to_drop:
             if line in conf["shell_command_after"]:
-                conf["shell_command_after"].remove(line)
+                remove_seq_item_with_comments(conf["shell_command_after"], line)
         if not conf["shell_command_after"]:
             del conf["shell_command_after"]
         self.update_merges_config(conf)
@@ -458,7 +458,7 @@ class Repo:
                 " having troubles removing that:\n"
                 f"Looking for: {line_to_drop}"
             )
-        conf["merges"].remove(line_to_drop)
+        remove_seq_item_with_comments(conf["merges"], line_to_drop)
         self.update_merges_config(conf)
 
     def remove_pending_pull_from_patches(self, upstream, pull_id):
@@ -470,7 +470,7 @@ class Repo:
         found = False
         for line in patches:
             if line_bit_to_drop in line:
-                patches.remove(line)
+                remove_seq_item_with_comments(patches, line)
                 found = True
                 break
         if not found:

--- a/odoo_tools/utils/yaml.py
+++ b/odoo_tools/utils/yaml.py
@@ -5,6 +5,8 @@ from pathlib import Path
 
 # TODO: do we really need this to edit such files?
 from ruamel.yaml import YAML
+from ruamel.yaml.error import CommentMark
+from ruamel.yaml.tokens import CommentToken
 
 yaml = YAML()
 
@@ -15,6 +17,84 @@ def yaml_load(stream):
 
 def yaml_dump(data, fileob):
     yaml.dump(data, fileob)
+
+
+def _comment_token(value, column=0):
+    return CommentToken(value, CommentMark(column), None)
+
+
+def _set_seq_start_comment(seq, leading):
+    """(Re)set the block comment that precedes a sequence's first item."""
+    comment = seq.ca.comment
+    if comment and comment[1]:
+        # When ``seq`` is a value in a mapping, this pre-comment list is the very
+        # same object as the parent map's slot, so mutating it in place updates
+        # both. An empty-value token clears it without breaking the block style.
+        comment[1][:] = [_comment_token(leading or "")]
+    elif leading:
+        token = _comment_token(leading)
+        if comment:
+            comment[1] = [token]
+        else:
+            seq.ca.comment = [None, [token]]
+
+
+def remove_seq_item_with_comments(seq, value):
+    """Remove ``value`` from a ruamel ``CommentedSeq`` along with the comments
+    that belong to it (its end-of-line comment and the block above it), keeping
+    every other item's comments anchored to that item.
+
+    ruamel does not model this directly: ``seq.ca.items[i]`` holds the comment
+    printed *after* item ``i`` -- which mixes item ``i``'s end-of-line comment
+    with the block comment that precedes item ``i + 1`` -- and the block above
+    the first item lives on the sequence's start comment. A plain
+    ``seq.remove(value)`` therefore drops the *next* item's comment and leaves
+    the removed item's block dangling on the survivor (upstream ticket, no stable
+    public API yet: https://sourceforge.net/p/ruamel-yaml/tickets/377/).
+
+    We sidestep that by normalising the stored comments into a per-item model
+    (each item's inline comment + the block above it), dropping the removed
+    item's entries, then rebuilding ``ca.items`` and the start comment. Inline
+    placement is restored from the token column; block indentation rides along
+    as leading whitespace inside the token value.
+    """
+    idx = seq.index(value)  # raises ValueError if absent, like list.remove
+    length = len(seq)
+    # Normalise: eol[i] = (text, column) of item i's end-of-line comment;
+    # above[i] = block printed before item i (above[length] trails the list).
+    eol = [None] * length
+    above = [None] * (length + 1)
+    for i, entry in seq.ca.items.items():
+        token = entry[0] if entry else None
+        if token is None:
+            continue
+        head, _, rest = token.value.partition("\n")
+        if head.strip():
+            eol[i] = (head + "\n", token.start_mark.column)
+        if rest:
+            above[i + 1] = rest
+    start = seq.ca.comment
+    if start and start[1]:
+        above[0] = "".join(token.value for token in start[1] if token is not None)
+    # Drop the item together with its own inline + preceding-block comments.
+    # ``above[idx + 1]`` shifts into ``idx``, staying anchored to the survivor.
+    del seq[idx]
+    eol.pop(idx)
+    above.pop(idx)
+    # Rebuild ruamel's storage from the model.
+    seq.ca.items.clear()
+    _set_seq_start_comment(seq, above[0])
+    for i in range(len(seq)):
+        inline, block = eol[i], above[i + 1]
+        if inline and block:
+            token = _comment_token(inline[0] + block, inline[1])
+        elif inline:
+            token = _comment_token(inline[0], inline[1])
+        elif block:
+            token = _comment_token("\n" + block)
+        else:
+            continue
+        seq.ca.items[i] = [token, None, None, None]
 
 
 def update_yml_file(path, new_data, main_key=None):

--- a/tests/test_utils_pending_merge.py
+++ b/tests/test_utils_pending_merge.py
@@ -749,6 +749,60 @@ def test_purge_merged_prs(project):
     assert "OCA refs/pull/759/head" in remaining
 
 
+def test_purge_merged_prs_with_comments(project):
+    """Purging a merged PR drops its own preceding comment block and keeps the
+    comment block of the still-pending PR that followed it."""
+    name = "edi"
+    tmpl = """
+../{ext_src_rel_path}/{repo_name}:
+  remotes:
+    camptocamp: git@github.com:camptocamp/{repo_name}.git
+    {org_name}: git@github.com:{org_name}/{repo_name}.git
+  target: camptocamp merge-branch-{pid}-master
+  merges:
+  - {org_name} 19.0
+  # [19.0][ADD] website_sale_stock_picking_policy
+  # https://github.com/OCA/{repo_name}/pull/1195
+  - {org_name} refs/pull/1195/head
+  # [19.0][ADD] website_sale_product_multiple_qty
+  # https://github.com/OCA/{repo_name}/pull/1172
+  - {org_name} refs/pull/1172/head
+"""
+    mock_pending_merge_repo_paths(name, tmpl=tmpl)
+    repo = Repo(name)
+    # 1195 is merged, 1172 is still open.
+    pr_states = {
+        1195: ("closed", True),
+        1172: ("open", False),
+    }
+    with mock.patch.object(
+        pm_utils.PendingPR,
+        "enrich_with_github",
+        autospec=True,
+        side_effect=_fake_enrich(pr_states),
+    ):
+        purged = list(repo.purge_merged_prs())
+    # Only the merged one is removed
+    assert [pr.pr for pr in purged] == [1195]
+    # The 1195 line and its comment block are gone; the 1172 line keeps its own
+    # comment block intact.
+    expected = dedent(
+        """\
+        ../odoo/external-src/edi:
+          remotes:
+            camptocamp: git@github.com:camptocamp/edi.git
+            OCA: git@github.com:OCA/edi.git
+          target: camptocamp merge-branch-1234-master
+          merges:
+            - OCA 19.0
+          # [19.0][ADD] website_sale_product_multiple_qty
+          # https://github.com/OCA/edi/pull/1172
+            - OCA refs/pull/1172/head
+        """
+    )
+    assert repo.abs_merges_path.read_text() == expected
+
+
 def _make_pending(repo, pr_id):
     return pm_utils.PendingPR(
         _repo=repo,

--- a/tests/test_utils_yaml.py
+++ b/tests/test_utils_yaml.py
@@ -1,0 +1,422 @@
+# Copyright 2024 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+
+import io
+from textwrap import dedent
+
+import pytest
+from ruamel.yaml import YAML
+
+from odoo_tools.utils.yaml import remove_seq_item_with_comments
+
+
+class TestRemoveSeqItemWithComments:
+    @staticmethod
+    def _roundtrip(src, value):
+        """Load ``src``, remove ``value`` from its top-level ``items`` sequence
+        and return the re-dumped document."""
+        yaml = YAML()
+        data = yaml.load(src)
+        remove_seq_item_with_comments(data["items"], value)
+        buf = io.StringIO()
+        yaml.dump(data, buf)
+        return buf.getvalue()
+
+    def test_remove_middle_item_keeps_following_comment(self):
+        """Removing an item drops its own (preceding) comment block, not the
+        next item's."""
+        src = dedent(
+            """\
+            items:
+            - a
+            # comment for b
+            - b
+            # comment for c
+            - c
+            """
+        )
+        result = self._roundtrip(src, "b")
+        expected = dedent(
+            """\
+            items:
+            - a
+            # comment for c
+            - c
+            """
+        )
+        assert result == expected
+
+    def test_remove_last_item_drops_its_comment(self):
+        src = dedent(
+            """\
+            items:
+            - a
+            # comment for b
+            - b
+            # comment for c
+            - c
+            """
+        )
+        result = self._roundtrip(src, "c")
+        expected = dedent(
+            """\
+            items:
+            - a
+            # comment for b
+            - b
+            """
+        )
+        assert result == expected
+
+    def test_remove_item_without_its_own_comment(self):
+        """An item with no preceding comment is removed cleanly, leaving the
+        other comments attached to their own items."""
+        src = dedent(
+            """\
+            items:
+            - a
+            - b
+            # comment for c
+            - c
+            """
+        )
+        result = self._roundtrip(src, "b")
+        expected = dedent(
+            """\
+            items:
+            - a
+            # comment for c
+            - c
+            """
+        )
+        assert result == expected
+
+    def test_remove_only_commented_item(self):
+        """Removing the single commented item also removes its comment block."""
+        src = dedent(
+            """\
+            items:
+            - a
+            # comment for b
+            - b
+            - c
+            """
+        )
+        result = self._roundtrip(src, "b")
+        expected = dedent(
+            """\
+            items:
+            - a
+            - c
+            """
+        )
+        assert result == expected
+
+    def test_remove_preserves_multiline_comment_blocks(self):
+        """The whole multi-line block above the removed item is dropped, and the
+        multi-line block above the survivor is kept verbatim."""
+        src = dedent(
+            """\
+            items:
+            - a
+            # b line 1
+            # b line 2
+            - b
+            # c line 1
+            # c line 2
+            - c
+            """
+        )
+        result = self._roundtrip(src, "b")
+        expected = dedent(
+            """\
+            items:
+            - a
+            # c line 1
+            # c line 2
+            - c
+            """
+        )
+        assert result == expected
+
+    def test_remove_with_blank_lines_between_comments(self):
+        """Blank lines belong to the comment block and travel with it: the
+        removed item's leading blank+comment go, the survivor's are kept."""
+        src = dedent(
+            """\
+            items:
+            - a
+
+            # comment for b
+            - b
+
+            # comment for c
+            - c
+            """
+        )
+        result = self._roundtrip(src, "b")
+        expected = dedent(
+            """\
+            items:
+            - a
+
+            # comment for c
+            - c
+            """
+        )
+        assert result == expected
+
+    def test_remove_keeps_trailing_comment_block(self):
+        """A comment block trailing the whole list is not anchored to any item
+        and stays put when an earlier item is removed."""
+        src = dedent(
+            """\
+            items:
+            - a
+            - b
+            # trailing block
+            """
+        )
+        result = self._roundtrip(src, "a")
+        expected = dedent(
+            """\
+            items:
+            - b
+            # trailing block
+            """
+        )
+        assert result == expected
+
+    def test_remove_only_item_with_comment_below(self):
+        """Removing the sole item empties the list; a comment that trailed it is
+        kept (it survives as the emptied list's leading comment) rather than
+        being silently dropped."""
+        src = dedent(
+            """\
+            items:
+            - a
+            # comment below a
+            """
+        )
+        result = self._roundtrip(src, "a")
+        assert result == "items:\n# comment below a\n[]\n"
+
+    def test_remove_absent_value_raises_value_error(self):
+        yaml = YAML()
+        data = yaml.load("items:\n- a\n- b\n")
+        with pytest.raises(ValueError):
+            remove_seq_item_with_comments(data["items"], "missing")
+
+    def test_remove_first_item_promotes_next_comment_to_leading(self):
+        """Removing the first item drops its own comment and the next item's
+        block comment becomes the sequence's leading comment."""
+        src = dedent(
+            """\
+            items:
+            - a
+            # comment for b
+            - b
+            # comment for c
+            - c
+            """
+        )
+        result = self._roundtrip(src, "a")
+        expected = dedent(
+            """\
+            items:
+            # comment for b
+            - b
+            # comment for c
+            - c
+            """
+        )
+        assert result == expected
+
+    def test_remove_first_item_drops_its_own_leading_comment(self):
+        """A comment above the first item describes it and is removed with it;
+        the next item's comment is promoted to leading."""
+        src = dedent(
+            """\
+            items:
+            # leading for a
+            - a
+            # comment for b
+            - b
+            """
+        )
+        result = self._roundtrip(src, "a")
+        expected = dedent(
+            """\
+            items:
+            # comment for b
+            - b
+            """
+        )
+        assert result == expected
+
+    def test_remove_first_item_clears_leading_when_nothing_follows(self):
+        """Removing the only-commented first item leaves the survivor with no
+        leading comment."""
+        src = dedent(
+            """\
+            items:
+            # leading for a
+            - a
+            - b
+            """
+        )
+        result = self._roundtrip(src, "a")
+        expected = dedent(
+            """\
+            items:
+            - b
+            """
+        )
+        assert result == expected
+
+    def test_remove_non_first_item_keeps_leading_comment(self):
+        """A leading comment that describes the first item is untouched when a
+        later item is removed."""
+        src = dedent(
+            """\
+            items:
+            # leading for a
+            - a
+            # comment for b
+            - b
+            """
+        )
+        result = self._roundtrip(src, "b")
+        expected = dedent(
+            """\
+            items:
+            # leading for a
+            - a
+            """
+        )
+        assert result == expected
+
+    def test_inline_eol_comments_stay_with_their_item(self):
+        """Inline (end-of-line) comments belong to their own item; removing one
+        item keeps the others' inline comments, indentation included."""
+        src = dedent(
+            """\
+            items:
+            - a  # inline a
+            - b  # inline b
+            - c  # inline c
+            """
+        )
+        result = self._roundtrip(src, "b")
+        expected = dedent(
+            """\
+            items:
+            - a  # inline a
+            - c  # inline c
+            """
+        )
+        assert result == expected
+
+    def test_inline_and_block_comments_combined(self):
+        """An item may carry both an inline comment and a block comment above
+        the next item; each is handled independently on removal."""
+        src = dedent(
+            """\
+            items:
+            - a  # inline a
+            # block for b
+            - b
+            - c
+            """
+        )
+        result = self._roundtrip(src, "b")
+        expected = dedent(
+            """\
+            items:
+            - a  # inline a
+            - c
+            """
+        )
+        assert result == expected
+
+
+class TestRuamelUpstreamCanary:
+    """Canaries for ruamel.yaml ticket #377 (mis-handling of block comments
+    when removing a sequence item).
+
+    These exercise *raw* ruamel (``CommentedSeq.remove``), NOT our
+    ``remove_seq_item_with_comments`` helper, and assert the result we'd get if
+    ruamel handled the comments itself. They are expected to FAIL today, so they
+    are marked ``xfail(strict=True)``: the day upstream fixes the bug they flip
+    to XPASS, which a strict xfail turns into a suite failure -- our signal to
+    drop the custom helper and go back to plain ``seq.remove(...)``.
+
+    (Inline end-of-line comments are intentionally not covered: raw ruamel
+    already handles those correctly; only block comments are affected.)
+
+    https://sourceforge.net/p/ruamel-yaml/tickets/377/
+    """
+
+    @staticmethod
+    def _raw_remove(src, value):
+        yaml = YAML()
+        data = yaml.load(src)
+        data["items"].remove(value)  # raw ruamel, no custom comment handling
+        buf = io.StringIO()
+        yaml.dump(data, buf)
+        return buf.getvalue()
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason="ruamel #377: raw remove keeps the removed item's block comment "
+        "and drops the next item's. When this passes, drop our helper.",
+    )
+    def test_raw_remove_middle_item_keeps_following_comment(self):
+        src = dedent(
+            """\
+            items:
+            - a
+            # comment for b
+            - b
+            # comment for c
+            - c
+            """
+        )
+        result = self._raw_remove(src, "b")
+        expected = dedent(
+            """\
+            items:
+            - a
+            # comment for c
+            - c
+            """
+        )
+        assert result == expected
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason="ruamel #377: raw remove of the first item drops the next item's "
+        "block comment instead of promoting it. When this passes, drop our helper.",
+    )
+    def test_raw_remove_first_item_promotes_next_comment(self):
+        src = dedent(
+            """\
+            items:
+            - a
+            # comment for b
+            - b
+            # comment for c
+            - c
+            """
+        )
+        result = self._raw_remove(src, "a")
+        expected = dedent(
+            """\
+            items:
+            # comment for b
+            - b
+            # comment for c
+            - c
+            """
+        )
+        assert result == expected


### PR DESCRIPTION
## Problem

`otools-pending clean` (and `otools-pending remove`) deleted the **wrong** comment block when removing a merged PR from a pending-merges file. Given:

```yaml
  merges:
  - OCA 19.0
  # [19.0][ADD] foo
  # https://github.com/OCA/repo/pull/1195
  - OCA refs/pull/1195/head
  # [19.0][ADD] bar
  # https://github.com/OCA/repo/pull/1172
  - OCA refs/pull/1172/head
```

removing the merged `1195` dropped the block above `1172` (the still-pending PR) and left `1195`'s block dangling on `1172`.

### Result

```diff
   merges:
   - OCA 19.0
   # [19.0][ADD] foo
   # https://github.com/OCA/repo/pull/1195
-  - OCA refs/pull/1195/head
-  # [19.0][ADD] bar
-  # https://github.com/OCA/repo/pull/1172
   - OCA refs/pull/1172/head
```

### Expected

```diff
   merges:
   - OCA 19.0
-  # [19.0][ADD] foo
-  # https://github.com/OCA/repo/pull/1195
-  - OCA refs/pull/1195/head
   # [19.0][ADD] bar
   # https://github.com/OCA/repo/pull/1172
   - OCA refs/pull/1172/head
```


## Root cause

`ruamel.yaml` stores a block comment against the index of the item it *follows* (`seq.ca.items[i]` is printed after item `i`), while we write comments *above* the line they describe. So a plain `CommentedSeq.remove()` removes the **next** item's comment instead of the removed item's.

Upstream ticket (no stable public API yet): https://sourceforge.net/p/ruamel-yaml/tickets/377/

## Fix

Add `remove_seq_item_with_comments` in `utils/yaml`, which normalises ruamel's comment storage into a per-item model (each item's end-of-line comment plus the block above it), drops the removed item's entries, and rebuilds the storage. It also correctly handles inline end-of-line comments and removal of the first item (promoting/clearing the sequence's leading comment).

Used at the three removal sites: `remove_pending_pull`, `remove_pending_commit`, `remove_pending_pull_from_patches`.

## Tests

- Direct unit tests for the helper, including the real indented pending-merge layout, blank lines, multi-line blocks, inline comments, and first-item edge cases.
- A regression test on the purge flow asserting the full expected file output.
- Two `xfail(strict=True)` **canary** tests that exercise *raw* ruamel: when upstream fixes #377 they start passing, turning the strict xfail into a failure — our signal to drop the custom helper and revert to plain `seq.remove(...)`.