### PR TITLE
[FIX] pending: don't let GitHub API failures break the rich rendering

### DIFF
--- a/odoo_tools/cli/pending.py
+++ b/odoo_tools/cli/pending.py
@@ -8,10 +8,12 @@ import arrow
 import click
 from rich.console import Console
 from rich.live import Live
+from rich.markup import escape
 from rich.spinner import Spinner
 from rich.table import Table
 
 from ..utils import pending_merge as pm_utils
+from ..utils import ui
 from ..utils.click import deprecated_option, global_command_decorators
 
 console = Console()
@@ -60,11 +62,21 @@ def show_pending(repo_paths=(), check=True, as_json=False):
     """List pull requests on <repo_path>."""
     repos = _resolve_repos(repo_paths, path_check=False)
     all_prs = [pr for repo in repos for pr in repo._iter_pending_pull_requests()]
+    if check:
+        ui.warn_missing_github_token()
+    # ids of PRs whose enrichment failed -> error message
+    errors: dict[int, str] = {}
     # In case of --json, output directly
     if as_json:
         if check:
             with ThreadPoolExecutor(max_workers=8) as pool:
-                list(pool.map(lambda pr: pr.enrich_with_github(), all_prs))
+                futures = {pool.submit(pr.enrich_with_github): pr for pr in all_prs}
+                for future in as_completed(futures):
+                    try:
+                        future.result()
+                    except Exception:
+                        # leave state as None in the JSON output
+                        pass
         click.echo(json.dumps([pr.to_dict() for pr in all_prs], indent=2, default=str))
         return
 
@@ -78,6 +90,10 @@ def show_pending(repo_paths=(), check=True, as_json=False):
         for pr in all_prs:
             if not check:
                 state_cell, updated, title = "-", "", ""
+            elif id(pr) in errors:
+                state_cell = "[red]?[/]"
+                updated = ""
+                title = f"[red]{escape(errors[id(pr)])}[/]"
             elif not pr.is_enriched:
                 state_cell, updated, title = Spinner("dots"), "", ""
             else:
@@ -99,8 +115,13 @@ def show_pending(repo_paths=(), check=True, as_json=False):
             Live(build_grid(), console=console, refresh_per_second=10) as live,
             ThreadPoolExecutor(max_workers=8) as pool,
         ):
-            futures = [pool.submit(pr.enrich_with_github) for pr in all_prs]
-            for _ in as_completed(futures):
+            futures = {pool.submit(pr.enrich_with_github): pr for pr in all_prs}
+            for future in as_completed(futures):
+                pr = futures[future]
+                try:
+                    future.result()
+                except Exception as exc:
+                    errors[id(pr)] = str(exc)
                 live.update(build_grid())
     else:
         console.print(build_grid())
@@ -125,17 +146,23 @@ def clean_pending(repo_paths=(), aggregate=True):
     all_prs = [pr for repo in repos for pr in repo._iter_pending_pull_requests()]
     if not all_prs:
         return
+    ui.warn_missing_github_token()
     touched_repos: set[pm_utils.Repo] = set()
     removed: set[int] = set()  # ids of PRs removed from their merges file
+    # ids of PRs whose enrichment failed -> error message
+    errors: dict[int, str] = {}
 
     def build_grid():
         grid = Table.grid(padding=(0, 1))
         grid.add_column(no_wrap=True)  # state dot / spinner
         grid.add_column(no_wrap=True)  # shortcut (linked)
         grid.add_column(no_wrap=True, style="dim")  # patch marker
-        grid.add_column(no_wrap=True)  # outcome
+        grid.add_column(no_wrap=True, overflow="ellipsis")  # outcome
         for pr in all_prs:
-            if not pr.is_enriched:
+            if id(pr) in errors:
+                state_cell = "[red]?[/]"
+                outcome = f"[red]{escape(errors[id(pr)])}[/]"
+            elif not pr.is_enriched:
                 state_cell, outcome = Spinner("dots"), ""
             elif id(pr) in removed:
                 state = "merged" if pr.merged else pr.state
@@ -160,8 +187,14 @@ def clean_pending(repo_paths=(), aggregate=True):
     ):
         futures = {pool.submit(pr.enrich_with_github): pr for pr in all_prs}
         for future in as_completed(futures):
-            future.result()
             pr = futures[future]
+            try:
+                future.result()
+            except Exception as exc:
+                # Leave the PR in place; we can't tell if it was merged.
+                errors[id(pr)] = str(exc)
+                live.update(build_grid())
+                continue
             if pr.merged:
                 if pr.is_patch:
                     pr._repo.remove_pending_pull_from_patches(pr.owner, pr.pr)

--- a/odoo_tools/cli/submodule.py
+++ b/odoo_tools/cli/submodule.py
@@ -160,6 +160,7 @@ def upgrade(submodule_path, force_branch):
     re-aggregate if needed.
     """
     odoo_version = proj.get_project_manifest_key("odoo_version")
+    ui.warn_missing_github_token()
     with path.cd(path.root_path()):
         for submodule in git.iter_gitmodules(filter_path=submodule_path):
             repo = pm_utils.Repo(submodule.path, path_check=False)

--- a/odoo_tools/utils/pending_merge.py
+++ b/odoo_tools/utils/pending_merge.py
@@ -92,23 +92,20 @@ class PendingPR:
         }
 
     def enrich_with_github(self) -> None:
-        """Fetch the PR's GitHub state and update this instance in place."""
+        """Fetch the PR's GitHub state and update this instance in place.
+
+        Raises ``requests.RequestException`` (e.g. ``HTTPError`` on a rate-limit
+        403, or a timeout/connection error) on failure; callers are expected to
+        catch and decide how to surface it.
+        """
         api_url = (
             f"https://api.github.com/repos/{self.owner}/{self.repo}/pulls/{self.pr}"
         )
         headers = {}
         if token := os.environ.get("GITHUB_TOKEN"):
             headers["Authorization"] = f"token {token}"
-        response = requests.get(api_url, headers=headers)
-        if not response.ok:
-            logger.warning(
-                "Could not get status of %s: %s %s",
-                self.shortcut,
-                response.status_code,
-                response.reason,
-            )
-            self.state = ""
-            return
+        response = requests.get(api_url, headers=headers, timeout=30)
+        response.raise_for_status()
         data = response.json()
         self.state = data.get("state") or ""
         self.merged = bool(data.get("merged"))
@@ -551,9 +548,17 @@ class Repo:
         Iterates the local pending-merges, enriches each one via the GitHub
         API, and yields the merged ones as soon as they are removed so that
         callers can report progress in real time.
+
+        A PR whose GitHub status can't be fetched (rate limit, timeout, …) is
+        left in place: we can't tell whether it was merged, so removing it
+        would be unsafe.
         """
         for pr in self._iter_pending_pull_requests():
-            pr.enrich_with_github()
+            try:
+                pr.enrich_with_github()
+            except requests.RequestException as exc:
+                logger.warning("Could not get status of %s: %s", pr.shortcut, exc)
+                continue
             if not pr.merged:
                 continue
             if pr.is_patch:

--- a/odoo_tools/utils/ui.py
+++ b/odoo_tools/utils/ui.py
@@ -1,13 +1,34 @@
 # Copyright 2023 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 
+import os
+
 import click
+from rich.console import Console
 
 from ..exceptions import Exit
+
+# Rich console writing to stderr, for warnings/diagnostics that must not be
+# mixed with a command's stdout (e.g. JSON output or a live-rendered table).
+err_console = Console(stderr=True)
 
 
 def exit_msg(msg):
     raise Exit(msg)
+
+
+def warn_missing_github_token():
+    """Warn (on stderr) when no GITHUB_TOKEN is set.
+
+    Unauthenticated GitHub API requests share a low rate limit and quickly
+    start failing; commands that hit the API should call this up front.
+    """
+    if not os.environ.get("GITHUB_TOKEN"):
+        err_console.print(
+            "Warning: GITHUB_TOKEN is not set; GitHub API requests "
+            "are unauthenticated and may hit rate limits.",
+            style="yellow",
+        )
 
 
 def ask_confirmation(message):

--- a/tests/test_utils_pending_merge.py
+++ b/tests/test_utils_pending_merge.py
@@ -6,6 +6,7 @@ from textwrap import dedent
 from unittest import mock
 
 import pytest
+import requests
 import responses
 from git.config import GitConfigParser
 
@@ -841,6 +842,45 @@ def test_purge_merged_prs(project):
     assert "OCA refs/pull/759/head" in remaining
 
 
+def test_purge_merged_prs_skips_unreachable(project, caplog):
+    """A PR whose status can't be fetched is left in place (with a warning),
+    and the failure doesn't abort purging the other PRs."""
+    name = "edi"
+    mock_pending_merge_repo_paths(name)
+    repo = Repo(name)
+    pr_states = {
+        774: ("open", False),
+        773: ("closed", True),
+        759: ("closed", False),
+    }
+    enrich = _fake_enrich(pr_states)
+
+    def enrich_or_fail(self):
+        # PR 774 is unreachable (e.g. rate limited); the rest succeed.
+        if self.pr == 774:
+            raise requests.HTTPError("403 rate limit exceeded")
+        enrich(self)
+
+    with (
+        mock.patch.object(
+            pm_utils.PendingPR,
+            "enrich_with_github",
+            autospec=True,
+            side_effect=enrich_or_fail,
+        ),
+        caplog.at_level("WARNING", logger="odoo_tools.utils.pending_merge"),
+    ):
+        purged = list(repo.purge_merged_prs())
+    # The merged PR is still removed; the unreachable one is left alone.
+    assert [pr.pr for pr in purged] == [773]
+    remaining = repo.merges_config()["merges"]
+    assert "OCA refs/pull/773/head" not in remaining
+    assert "OCA refs/pull/774/head" in remaining
+    assert "OCA refs/pull/759/head" in remaining
+    # The failure is reported via a log warning.
+    assert "OCA/edi#774" in caplog.text
+
+
 def test_purge_merged_prs_with_comments(project):
     """Purging a merged PR drops its own preceding comment block and keeps the
     comment block of the still-pending PR that followed it."""
@@ -944,13 +984,31 @@ def test_enrich_with_github_api_error(project):
         rsps.add(
             responses.GET,
             "https://api.github.com/repos/OCA/edi/pulls/9999",
-            status=404,
+            status=403,
         )
-        pending.enrich_with_github()
-    # Empty state on API failure means purge_merged_prs won't touch it
-    assert pending.is_enriched
-    assert pending.state == ""
-    assert pending.merged is False
+        # The error is raised loudly; callers decide how to surface it.
+        with pytest.raises(requests.HTTPError):
+            pending.enrich_with_github()
+    # State is left untouched (not enriched) so callers can flag the failure.
+    assert not pending.is_enriched
+    assert pending.state is None
+
+
+def test_enrich_with_github_connection_error(project):
+    name = "edi"
+    mock_pending_merge_repo_paths(name)
+    repo = Repo(name)
+    pending = _make_pending(repo, 9999)
+    with responses.RequestsMock() as rsps:
+        rsps.add(
+            responses.GET,
+            "https://api.github.com/repos/OCA/edi/pulls/9999",
+            body=requests.ConnectionError("boom"),
+        )
+        with pytest.raises(requests.ConnectionError):
+            pending.enrich_with_github()
+    assert not pending.is_enriched
+    assert pending.state is None
 
 
 def test_enrich_with_github_uses_token(project, monkeypatch):


### PR DESCRIPTION
When GITHUB_TOKEN was unset, unauthenticated GitHub API requests quickly hit the rate limit. The failure was handled inside enrich_with_github with a logger.warning emitted from ThreadPoolExecutor worker threads, which the root StreamHandler wrote straight to stderr, interleaving with the live rich table and corrupting the output.

<img width="2800" height="390" alt="image" src="https://github.com/user-attachments/assets/f8394635-95bd-4cd5-bb5d-0df289fa0fdf" />

`enrich_with_github` now fails loudly: it adds a request timeout and calls raise_for_status, letting requests exceptions propagate so the callers that own the rendering decide how to surface them.

The CLI commands (show/clean) catch per-PR, mark the failure and render it inline in red (red "?" plus the error message), so a failed lookup no longer keeps spinning and nothing interleaves with the table. They also warn up front, before any rendering, when GITHUB_TOKEN is missing. That warning lives in a shared ui.warn_missing_github_token helper so show, clean and submodule upgrade all emit the exact same message.

<img width="2234" height="222" alt="image" src="https://github.com/user-attachments/assets/a50b70be-a3c0-4283-96bc-1c04da5f02c8" />


purge_merged_prs (used by submodule upgrade, which has no thread pool nor live table) keeps a logger.warning and simply leaves the PR in place when its status can't be determined, so a transient failure no longer aborts the whole upgrade.

