### PR TITLE
[FIX] release workflow: upload build to the release via gh CLI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,18 +3,26 @@ name: Release
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to build and upload to (e.g. 0.17.2)"
+        required: true
 
 jobs:
   build:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    env:
+      RELEASE_TAG: ${{ github.event.release.tag_name || inputs.tag }}
     steps:
       - uses: actions/checkout@v7
         with:
+          ref: ${{ env.RELEASE_TAG }}
           fetch-depth: 0
       - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
       - run: uv build
-      - uses: softprops/action-gh-release@v3
-        with:
-          files: dist/*
+      - run: gh release upload "$RELEASE_TAG" dist/* --clobber
+        env:
+          GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Problem

The `Release` workflow has been failing on **every** release with:

```
Error: ⚠️ GitHub Releases requires a tag
```

It used `softprops/action-gh-release`, which defaults `tag_name` to `github.ref_name`. For our `release: published` runs, `GITHUB_REF` resolves to `refs/heads/master` (the release tag targets master's HEAD), so `ref_name` is `master` — a branch, not a tag — and the action bails out before uploading anything.

## Fix

Replace the third-party action with the preinstalled `gh` CLI, which uploads the built artifacts straight to the release that triggered the workflow:

```yaml
- run: gh release upload "$RELEASE_TAG" dist/* --clobber
  env:
    GH_TOKEN: ${{ github.token }}
```

The release is created from the GitHub UI (with auto-generated notes); this workflow only attaches the `dist/*` build artifacts to it — it does not touch the release title or body.

## Also in this PR

- **`workflow_dispatch` trigger** taking the tag as input, so a release can be (re)built and re-uploaded manually for an existing tag — handy for testing or fixing a botched upload.
- **Check out the release tag explicitly** (`ref: $RELEASE_TAG`) instead of the default branch HEAD, so `hatch-vcs` derives the version from the right commit.
- `--clobber` keeps re-runs idempotent.
- Drops a third-party action dependency.

## Testing

`workflow_dispatch` allows manual validation against an existing tag once this is on the target branch.