### PR TITLE
[IMP] add tab completion on the tools

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,7 @@ jobs:
           ref: ${{ env.RELEASE_TAG }}
           fetch-depth: 0
       - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+      - run: make release-assets
       - run: uv build
       - run: gh release upload "$RELEASE_TAG" dist/* --clobber
         env:

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+.PHONY: help completions release-assets clean-dist
+
+help:
+	@echo "Available targets:"
+	@echo "  completions    Generate Click native shell completions"
+	@echo "  release-assets Generate completions and build release artifacts"
+	@echo "  clean-dist     Remove build artifacts"
+
+completions:
+	uv run python scripts/generate_completions.py
+
+release-assets: clean-dist completions
+	uv build
+
+clean-dist:
+	rm -rf dist build

--- a/README.md
+++ b/README.md
@@ -22,6 +22,14 @@ You may need to have some build dependencies installed:
 
     sudo apt install pipx git libpq-dev gcc python3-dev
 
+  ## Shell completion
+
+  Pre-generated shell completion scripts are shipped in the package for bash,
+  zsh, and fish.
+
+  Run `otools-setup shell-completion` after installing to configure your shell
+  automatically.  See `docs/shell-completions.md` for manual setup instructions.
+
 ## Usage
 
 Note: information below is subject to change.
@@ -51,6 +59,8 @@ The package brings the following commands.
 `otools-i18n`: tools to manage internationalization (i18n)
 
 `otools-password`: tools to manage admin passwords and LastPass entries
+
+`otools-setup`: post-install configuration (shell completion setup, …)
 
 Use `--help` to get the list of subcommands.
 

--- a/changes.d/otools-shell-completions.feature
+++ b/changes.d/otools-shell-completions.feature
@@ -1,0 +1,3 @@
+Ship pre-generated native Click shell completions for all ``otools-*``
+commands (bash, zsh, fish), include them in package data, and document
+installation/activation instructions.

--- a/docs/shell-completions.md
+++ b/docs/shell-completions.md
@@ -1,0 +1,89 @@
+# Shell completions
+
+This project ships pre-generated completion scripts for all `otools-*`
+commands using native Click 8 shell completion support.
+
+Supported shells:
+
+- bash
+- zsh
+- fish
+
+The completion files are installed as package data under
+`odoo_tools/completions/`.
+
+## Automatic setup (recommended)
+
+After installing `odoo-tools`, run:
+
+```bash
+otools-setup shell-completion
+```
+
+The command will:
+
+1. Detect your current shell from `$SHELL` (or accept `--shell <bash|zsh|fish>`).
+2. Resolve the installed completion directory.
+3. Show the exact change it will make to your shell startup file.
+4. Write the change only after you confirm.
+
+For **fish** it copies the completion files to `~/.config/fish/completions/`
+instead of editing a startup file.
+
+After setup, reload your shell (e.g. `source ~/.bashrc` or open a new terminal).
+
+---
+
+## Manual setup
+
+Follow the steps below if you prefer not to use `otools-setup`.
+
+### Locate the installed completion directory
+
+Run:
+
+```bash
+python -c "from importlib.resources import files; print(files('odoo_tools.completions'))"
+```
+
+Store it in a variable:
+
+```bash
+OTOOLS_COMPLETIONS_DIR="$(python -c "from importlib.resources import files; print(files('odoo_tools.completions'))")"
+```
+
+### Bash
+
+Load for current shell:
+
+```bash
+for f in "$OTOOLS_COMPLETIONS_DIR"/bash/*; do
+  # shellcheck disable=SC1090
+  source "$f"
+done
+```
+
+Persist in `~/.bashrc` by adding the same loop.
+
+### Zsh
+
+Load for current shell:
+
+```zsh
+fpath=("$OTOOLS_COMPLETIONS_DIR/zsh" $fpath)
+autoload -Uz compinit
+compinit
+```
+
+Persist by adding these lines to `~/.zshrc`.
+
+### Fish
+
+Install once by copying files to the default fish completions directory:
+
+```bash
+mkdir -p ~/.config/fish/completions
+cp "$OTOOLS_COMPLETIONS_DIR"/fish/*.fish ~/.config/fish/completions/
+```
+
+Open a new fish session (or run `exec fish`).

--- a/odoo_tools/cli/setup.py
+++ b/odoo_tools/cli/setup.py
@@ -1,0 +1,119 @@
+# Copyright 2026 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+"""otools-setup — post-install configuration helper.
+
+This command group is intentionally extensible: new setup actions should be
+added as subcommands here rather than as standalone entry points.
+"""
+
+from __future__ import annotations
+
+import shutil
+
+import click
+
+from ..utils.click import global_command_decorators
+from ..utils.completion import (
+    SHELLS,
+    detect_shell,
+    diff_rc_content,
+    fish_completions_dir,
+    installed_completions_dir,
+    shell_rc_file,
+    update_rc_content,
+)
+
+
+@click.group()
+@global_command_decorators
+def cli():
+    """Post-install setup for odoo-tools."""
+
+
+@cli.command("shell-completion")
+@click.option(
+    "--shell",
+    "shell_name",
+    default=None,
+    type=click.Choice(SHELLS),
+    help="Target shell.  Defaults to the value of the SHELL environment variable.",
+)
+def shell_completion(shell_name: str | None) -> None:
+    """Configure shell completion for all otools-* commands.
+
+    Detects your shell, resolves the installed completion directory, and
+    updates your shell startup file with the required snippet.  The proposed
+    change is shown before anything is written so you can review it first.
+
+    For fish the completion files are copied to ~/.config/fish/completions/;
+    no RC-file edit is needed.
+    """
+    # --- shell detection ---------------------------------------------------
+    if shell_name is None:
+        shell_name = detect_shell()
+        if shell_name is None:
+            raise click.ClickException(
+                "Could not detect your shell from $SHELL.  "
+                "Pass --shell <bash|zsh|fish> explicitly."
+            )
+        click.echo(f"Detected shell: {shell_name}")
+
+    completions_dir = installed_completions_dir()
+
+    # --- fish: copy files, no RC edit needed --------------------------------
+    if shell_name == "fish":
+        _setup_fish(completions_dir)
+        return
+
+    # --- bash / zsh: update RC file ----------------------------------------
+    rc_path = shell_rc_file(shell_name)
+    assert rc_path is not None  # guaranteed for bash/zsh
+
+    existing = rc_path.read_text() if rc_path.exists() else ""
+    updated = update_rc_content(existing, shell_name, completions_dir)
+
+    if existing == updated:
+        click.echo(f"{rc_path} is already up to date.  Nothing to do.")
+        return
+
+    diff = diff_rc_content(existing, updated, rc_path)
+    click.echo(f"\nProposed changes to {rc_path}:\n")
+    click.echo(diff)
+
+    if not click.confirm("Apply these changes?"):
+        raise click.Abort()
+
+    rc_path.write_text(updated)
+    click.echo(f"Updated {rc_path}.")
+    click.echo("Reload your shell (e.g. `source {rc_path}`) to activate completion.")
+
+
+def _setup_fish(completions_dir):
+    """Copy fish completion files to the fish completions directory."""
+    fish_dir = fish_completions_dir()
+    fish_dir.mkdir(parents=True, exist_ok=True)
+    source_dir = completions_dir / "fish"
+    if not source_dir.exists():
+        raise click.ClickException(f"Fish completion sources not found at {source_dir}")
+
+    fish_files = list(source_dir.glob("*.fish"))
+    if not fish_files:
+        raise click.ClickException(f"No .fish completion files found in {source_dir}")
+
+    click.echo(f"Will copy {len(fish_files)} file(s) to {fish_dir}:\n")
+    for f in sorted(fish_files):
+        click.echo(f"  {f.name}")
+
+    click.echo()
+    if not click.confirm("Apply?"):
+        raise click.Abort()
+
+    for f in fish_files:
+        shutil.copy2(f, fish_dir / f.name)
+
+    click.echo(f"Copied {len(fish_files)} completion file(s) to {fish_dir}.")
+    click.echo("Open a new fish session (or run `exec fish`) to activate completion.")
+
+
+if __name__ == "__main__":
+    cli()

--- a/odoo_tools/completions/__init__.py
+++ b/odoo_tools/completions/__init__.py
@@ -1,0 +1,1 @@
+# Package containing pre-generated shell completion scripts.

--- a/odoo_tools/completions/bash/otools-addon
+++ b/odoo_tools/completions/bash/otools-addon
@@ -1,0 +1,28 @@
+_otools_addon_completion() {
+    local IFS=$'\n'
+    local response
+
+    response=$(env COMP_WORDS="${COMP_WORDS[*]}" COMP_CWORD=$COMP_CWORD _OTOOLS_ADDON_COMPLETE=bash_complete $1)
+
+    for completion in $response; do
+        IFS=',' read type value <<< "$completion"
+
+        if [[ $type == 'dir' ]]; then
+            COMPREPLY=()
+            compopt -o dirnames
+        elif [[ $type == 'file' ]]; then
+            COMPREPLY=()
+            compopt -o default
+        elif [[ $type == 'plain' ]]; then
+            COMPREPLY+=($value)
+        fi
+    done
+
+    return 0
+}
+
+_otools_addon_completion_setup() {
+    complete -o nosort -F _otools_addon_completion otools-addon
+}
+
+_otools_addon_completion_setup;

--- a/odoo_tools/completions/bash/otools-ba
+++ b/odoo_tools/completions/bash/otools-ba
@@ -1,0 +1,28 @@
+_otools_ba_completion() {
+    local IFS=$'\n'
+    local response
+
+    response=$(env COMP_WORDS="${COMP_WORDS[*]}" COMP_CWORD=$COMP_CWORD _OTOOLS_BA_COMPLETE=bash_complete $1)
+
+    for completion in $response; do
+        IFS=',' read type value <<< "$completion"
+
+        if [[ $type == 'dir' ]]; then
+            COMPREPLY=()
+            compopt -o dirnames
+        elif [[ $type == 'file' ]]; then
+            COMPREPLY=()
+            compopt -o default
+        elif [[ $type == 'plain' ]]; then
+            COMPREPLY+=($value)
+        fi
+    done
+
+    return 0
+}
+
+_otools_ba_completion_setup() {
+    complete -o nosort -F _otools_ba_completion otools-ba
+}
+
+_otools_ba_completion_setup;

--- a/odoo_tools/completions/bash/otools-cloud
+++ b/odoo_tools/completions/bash/otools-cloud
@@ -1,0 +1,28 @@
+_otools_cloud_completion() {
+    local IFS=$'\n'
+    local response
+
+    response=$(env COMP_WORDS="${COMP_WORDS[*]}" COMP_CWORD=$COMP_CWORD _OTOOLS_CLOUD_COMPLETE=bash_complete $1)
+
+    for completion in $response; do
+        IFS=',' read type value <<< "$completion"
+
+        if [[ $type == 'dir' ]]; then
+            COMPREPLY=()
+            compopt -o dirnames
+        elif [[ $type == 'file' ]]; then
+            COMPREPLY=()
+            compopt -o default
+        elif [[ $type == 'plain' ]]; then
+            COMPREPLY+=($value)
+        fi
+    done
+
+    return 0
+}
+
+_otools_cloud_completion_setup() {
+    complete -o nosort -F _otools_cloud_completion otools-cloud
+}
+
+_otools_cloud_completion_setup;

--- a/odoo_tools/completions/bash/otools-db
+++ b/odoo_tools/completions/bash/otools-db
@@ -1,0 +1,28 @@
+_otools_db_completion() {
+    local IFS=$'\n'
+    local response
+
+    response=$(env COMP_WORDS="${COMP_WORDS[*]}" COMP_CWORD=$COMP_CWORD _OTOOLS_DB_COMPLETE=bash_complete $1)
+
+    for completion in $response; do
+        IFS=',' read type value <<< "$completion"
+
+        if [[ $type == 'dir' ]]; then
+            COMPREPLY=()
+            compopt -o dirnames
+        elif [[ $type == 'file' ]]; then
+            COMPREPLY=()
+            compopt -o default
+        elif [[ $type == 'plain' ]]; then
+            COMPREPLY+=($value)
+        fi
+    done
+
+    return 0
+}
+
+_otools_db_completion_setup() {
+    complete -o nosort -F _otools_db_completion otools-db
+}
+
+_otools_db_completion_setup;

--- a/odoo_tools/completions/bash/otools-i18n
+++ b/odoo_tools/completions/bash/otools-i18n
@@ -1,0 +1,28 @@
+_otools_i18n_completion() {
+    local IFS=$'\n'
+    local response
+
+    response=$(env COMP_WORDS="${COMP_WORDS[*]}" COMP_CWORD=$COMP_CWORD _OTOOLS_I18N_COMPLETE=bash_complete $1)
+
+    for completion in $response; do
+        IFS=',' read type value <<< "$completion"
+
+        if [[ $type == 'dir' ]]; then
+            COMPREPLY=()
+            compopt -o dirnames
+        elif [[ $type == 'file' ]]; then
+            COMPREPLY=()
+            compopt -o default
+        elif [[ $type == 'plain' ]]; then
+            COMPREPLY+=($value)
+        fi
+    done
+
+    return 0
+}
+
+_otools_i18n_completion_setup() {
+    complete -o nosort -F _otools_i18n_completion otools-i18n
+}
+
+_otools_i18n_completion_setup;

--- a/odoo_tools/completions/bash/otools-migrate-db
+++ b/odoo_tools/completions/bash/otools-migrate-db
@@ -1,0 +1,28 @@
+_otools_migrate_db_completion() {
+    local IFS=$'\n'
+    local response
+
+    response=$(env COMP_WORDS="${COMP_WORDS[*]}" COMP_CWORD=$COMP_CWORD _OTOOLS_MIGRATE_DB_COMPLETE=bash_complete $1)
+
+    for completion in $response; do
+        IFS=',' read type value <<< "$completion"
+
+        if [[ $type == 'dir' ]]; then
+            COMPREPLY=()
+            compopt -o dirnames
+        elif [[ $type == 'file' ]]; then
+            COMPREPLY=()
+            compopt -o default
+        elif [[ $type == 'plain' ]]; then
+            COMPREPLY+=($value)
+        fi
+    done
+
+    return 0
+}
+
+_otools_migrate_db_completion_setup() {
+    complete -o nosort -F _otools_migrate_db_completion otools-migrate-db
+}
+
+_otools_migrate_db_completion_setup;

--- a/odoo_tools/completions/bash/otools-password
+++ b/odoo_tools/completions/bash/otools-password
@@ -1,0 +1,28 @@
+_otools_password_completion() {
+    local IFS=$'\n'
+    local response
+
+    response=$(env COMP_WORDS="${COMP_WORDS[*]}" COMP_CWORD=$COMP_CWORD _OTOOLS_PASSWORD_COMPLETE=bash_complete $1)
+
+    for completion in $response; do
+        IFS=',' read type value <<< "$completion"
+
+        if [[ $type == 'dir' ]]; then
+            COMPREPLY=()
+            compopt -o dirnames
+        elif [[ $type == 'file' ]]; then
+            COMPREPLY=()
+            compopt -o default
+        elif [[ $type == 'plain' ]]; then
+            COMPREPLY+=($value)
+        fi
+    done
+
+    return 0
+}
+
+_otools_password_completion_setup() {
+    complete -o nosort -F _otools_password_completion otools-password
+}
+
+_otools_password_completion_setup;

--- a/odoo_tools/completions/bash/otools-pending
+++ b/odoo_tools/completions/bash/otools-pending
@@ -1,0 +1,28 @@
+_otools_pending_completion() {
+    local IFS=$'\n'
+    local response
+
+    response=$(env COMP_WORDS="${COMP_WORDS[*]}" COMP_CWORD=$COMP_CWORD _OTOOLS_PENDING_COMPLETE=bash_complete $1)
+
+    for completion in $response; do
+        IFS=',' read type value <<< "$completion"
+
+        if [[ $type == 'dir' ]]; then
+            COMPREPLY=()
+            compopt -o dirnames
+        elif [[ $type == 'file' ]]; then
+            COMPREPLY=()
+            compopt -o default
+        elif [[ $type == 'plain' ]]; then
+            COMPREPLY+=($value)
+        fi
+    done
+
+    return 0
+}
+
+_otools_pending_completion_setup() {
+    complete -o nosort -F _otools_pending_completion otools-pending
+}
+
+_otools_pending_completion_setup;

--- a/odoo_tools/completions/bash/otools-pr
+++ b/odoo_tools/completions/bash/otools-pr
@@ -1,0 +1,28 @@
+_otools_pr_completion() {
+    local IFS=$'\n'
+    local response
+
+    response=$(env COMP_WORDS="${COMP_WORDS[*]}" COMP_CWORD=$COMP_CWORD _OTOOLS_PR_COMPLETE=bash_complete $1)
+
+    for completion in $response; do
+        IFS=',' read type value <<< "$completion"
+
+        if [[ $type == 'dir' ]]; then
+            COMPREPLY=()
+            compopt -o dirnames
+        elif [[ $type == 'file' ]]; then
+            COMPREPLY=()
+            compopt -o default
+        elif [[ $type == 'plain' ]]; then
+            COMPREPLY+=($value)
+        fi
+    done
+
+    return 0
+}
+
+_otools_pr_completion_setup() {
+    complete -o nosort -F _otools_pr_completion otools-pr
+}
+
+_otools_pr_completion_setup;

--- a/odoo_tools/completions/bash/otools-project
+++ b/odoo_tools/completions/bash/otools-project
@@ -1,0 +1,28 @@
+_otools_project_completion() {
+    local IFS=$'\n'
+    local response
+
+    response=$(env COMP_WORDS="${COMP_WORDS[*]}" COMP_CWORD=$COMP_CWORD _OTOOLS_PROJECT_COMPLETE=bash_complete $1)
+
+    for completion in $response; do
+        IFS=',' read type value <<< "$completion"
+
+        if [[ $type == 'dir' ]]; then
+            COMPREPLY=()
+            compopt -o dirnames
+        elif [[ $type == 'file' ]]; then
+            COMPREPLY=()
+            compopt -o default
+        elif [[ $type == 'plain' ]]; then
+            COMPREPLY+=($value)
+        fi
+    done
+
+    return 0
+}
+
+_otools_project_completion_setup() {
+    complete -o nosort -F _otools_project_completion otools-project
+}
+
+_otools_project_completion_setup;

--- a/odoo_tools/completions/bash/otools-release
+++ b/odoo_tools/completions/bash/otools-release
@@ -1,0 +1,28 @@
+_otools_release_completion() {
+    local IFS=$'\n'
+    local response
+
+    response=$(env COMP_WORDS="${COMP_WORDS[*]}" COMP_CWORD=$COMP_CWORD _OTOOLS_RELEASE_COMPLETE=bash_complete $1)
+
+    for completion in $response; do
+        IFS=',' read type value <<< "$completion"
+
+        if [[ $type == 'dir' ]]; then
+            COMPREPLY=()
+            compopt -o dirnames
+        elif [[ $type == 'file' ]]; then
+            COMPREPLY=()
+            compopt -o default
+        elif [[ $type == 'plain' ]]; then
+            COMPREPLY+=($value)
+        fi
+    done
+
+    return 0
+}
+
+_otools_release_completion_setup() {
+    complete -o nosort -F _otools_release_completion otools-release
+}
+
+_otools_release_completion_setup;

--- a/odoo_tools/completions/bash/otools-submodule
+++ b/odoo_tools/completions/bash/otools-submodule
@@ -1,0 +1,28 @@
+_otools_submodule_completion() {
+    local IFS=$'\n'
+    local response
+
+    response=$(env COMP_WORDS="${COMP_WORDS[*]}" COMP_CWORD=$COMP_CWORD _OTOOLS_SUBMODULE_COMPLETE=bash_complete $1)
+
+    for completion in $response; do
+        IFS=',' read type value <<< "$completion"
+
+        if [[ $type == 'dir' ]]; then
+            COMPREPLY=()
+            compopt -o dirnames
+        elif [[ $type == 'file' ]]; then
+            COMPREPLY=()
+            compopt -o default
+        elif [[ $type == 'plain' ]]; then
+            COMPREPLY+=($value)
+        fi
+    done
+
+    return 0
+}
+
+_otools_submodule_completion_setup() {
+    complete -o nosort -F _otools_submodule_completion otools-submodule
+}
+
+_otools_submodule_completion_setup;

--- a/odoo_tools/completions/fish/otools-addon.fish
+++ b/odoo_tools/completions/fish/otools-addon.fish
@@ -1,0 +1,17 @@
+function _otools_addon_completion;
+    set -l response (env _OTOOLS_ADDON_COMPLETE=fish_complete COMP_WORDS=(commandline -cp) COMP_CWORD=(commandline -t) otools-addon);
+
+    for completion in $response;
+        set -l metadata (string split "," $completion);
+
+        if test $metadata[1] = "dir";
+            __fish_complete_directories $metadata[2];
+        else if test $metadata[1] = "file";
+            __fish_complete_path $metadata[2];
+        else if test $metadata[1] = "plain";
+            echo $metadata[2];
+        end;
+    end;
+end;
+
+complete --no-files --command otools-addon --arguments "(_otools_addon_completion)";

--- a/odoo_tools/completions/fish/otools-ba.fish
+++ b/odoo_tools/completions/fish/otools-ba.fish
@@ -1,0 +1,17 @@
+function _otools_ba_completion;
+    set -l response (env _OTOOLS_BA_COMPLETE=fish_complete COMP_WORDS=(commandline -cp) COMP_CWORD=(commandline -t) otools-ba);
+
+    for completion in $response;
+        set -l metadata (string split "," $completion);
+
+        if test $metadata[1] = "dir";
+            __fish_complete_directories $metadata[2];
+        else if test $metadata[1] = "file";
+            __fish_complete_path $metadata[2];
+        else if test $metadata[1] = "plain";
+            echo $metadata[2];
+        end;
+    end;
+end;
+
+complete --no-files --command otools-ba --arguments "(_otools_ba_completion)";

--- a/odoo_tools/completions/fish/otools-cloud.fish
+++ b/odoo_tools/completions/fish/otools-cloud.fish
@@ -1,0 +1,17 @@
+function _otools_cloud_completion;
+    set -l response (env _OTOOLS_CLOUD_COMPLETE=fish_complete COMP_WORDS=(commandline -cp) COMP_CWORD=(commandline -t) otools-cloud);
+
+    for completion in $response;
+        set -l metadata (string split "," $completion);
+
+        if test $metadata[1] = "dir";
+            __fish_complete_directories $metadata[2];
+        else if test $metadata[1] = "file";
+            __fish_complete_path $metadata[2];
+        else if test $metadata[1] = "plain";
+            echo $metadata[2];
+        end;
+    end;
+end;
+
+complete --no-files --command otools-cloud --arguments "(_otools_cloud_completion)";

--- a/odoo_tools/completions/fish/otools-db.fish
+++ b/odoo_tools/completions/fish/otools-db.fish
@@ -1,0 +1,17 @@
+function _otools_db_completion;
+    set -l response (env _OTOOLS_DB_COMPLETE=fish_complete COMP_WORDS=(commandline -cp) COMP_CWORD=(commandline -t) otools-db);
+
+    for completion in $response;
+        set -l metadata (string split "," $completion);
+
+        if test $metadata[1] = "dir";
+            __fish_complete_directories $metadata[2];
+        else if test $metadata[1] = "file";
+            __fish_complete_path $metadata[2];
+        else if test $metadata[1] = "plain";
+            echo $metadata[2];
+        end;
+    end;
+end;
+
+complete --no-files --command otools-db --arguments "(_otools_db_completion)";

--- a/odoo_tools/completions/fish/otools-i18n.fish
+++ b/odoo_tools/completions/fish/otools-i18n.fish
@@ -1,0 +1,17 @@
+function _otools_i18n_completion;
+    set -l response (env _OTOOLS_I18N_COMPLETE=fish_complete COMP_WORDS=(commandline -cp) COMP_CWORD=(commandline -t) otools-i18n);
+
+    for completion in $response;
+        set -l metadata (string split "," $completion);
+
+        if test $metadata[1] = "dir";
+            __fish_complete_directories $metadata[2];
+        else if test $metadata[1] = "file";
+            __fish_complete_path $metadata[2];
+        else if test $metadata[1] = "plain";
+            echo $metadata[2];
+        end;
+    end;
+end;
+
+complete --no-files --command otools-i18n --arguments "(_otools_i18n_completion)";

--- a/odoo_tools/completions/fish/otools-migrate-db.fish
+++ b/odoo_tools/completions/fish/otools-migrate-db.fish
@@ -1,0 +1,17 @@
+function _otools_migrate_db_completion;
+    set -l response (env _OTOOLS_MIGRATE_DB_COMPLETE=fish_complete COMP_WORDS=(commandline -cp) COMP_CWORD=(commandline -t) otools-migrate-db);
+
+    for completion in $response;
+        set -l metadata (string split "," $completion);
+
+        if test $metadata[1] = "dir";
+            __fish_complete_directories $metadata[2];
+        else if test $metadata[1] = "file";
+            __fish_complete_path $metadata[2];
+        else if test $metadata[1] = "plain";
+            echo $metadata[2];
+        end;
+    end;
+end;
+
+complete --no-files --command otools-migrate-db --arguments "(_otools_migrate_db_completion)";

--- a/odoo_tools/completions/fish/otools-password.fish
+++ b/odoo_tools/completions/fish/otools-password.fish
@@ -1,0 +1,17 @@
+function _otools_password_completion;
+    set -l response (env _OTOOLS_PASSWORD_COMPLETE=fish_complete COMP_WORDS=(commandline -cp) COMP_CWORD=(commandline -t) otools-password);
+
+    for completion in $response;
+        set -l metadata (string split "," $completion);
+
+        if test $metadata[1] = "dir";
+            __fish_complete_directories $metadata[2];
+        else if test $metadata[1] = "file";
+            __fish_complete_path $metadata[2];
+        else if test $metadata[1] = "plain";
+            echo $metadata[2];
+        end;
+    end;
+end;
+
+complete --no-files --command otools-password --arguments "(_otools_password_completion)";

--- a/odoo_tools/completions/fish/otools-pending.fish
+++ b/odoo_tools/completions/fish/otools-pending.fish
@@ -1,0 +1,17 @@
+function _otools_pending_completion;
+    set -l response (env _OTOOLS_PENDING_COMPLETE=fish_complete COMP_WORDS=(commandline -cp) COMP_CWORD=(commandline -t) otools-pending);
+
+    for completion in $response;
+        set -l metadata (string split "," $completion);
+
+        if test $metadata[1] = "dir";
+            __fish_complete_directories $metadata[2];
+        else if test $metadata[1] = "file";
+            __fish_complete_path $metadata[2];
+        else if test $metadata[1] = "plain";
+            echo $metadata[2];
+        end;
+    end;
+end;
+
+complete --no-files --command otools-pending --arguments "(_otools_pending_completion)";

--- a/odoo_tools/completions/fish/otools-pr.fish
+++ b/odoo_tools/completions/fish/otools-pr.fish
@@ -1,0 +1,17 @@
+function _otools_pr_completion;
+    set -l response (env _OTOOLS_PR_COMPLETE=fish_complete COMP_WORDS=(commandline -cp) COMP_CWORD=(commandline -t) otools-pr);
+
+    for completion in $response;
+        set -l metadata (string split "," $completion);
+
+        if test $metadata[1] = "dir";
+            __fish_complete_directories $metadata[2];
+        else if test $metadata[1] = "file";
+            __fish_complete_path $metadata[2];
+        else if test $metadata[1] = "plain";
+            echo $metadata[2];
+        end;
+    end;
+end;
+
+complete --no-files --command otools-pr --arguments "(_otools_pr_completion)";

--- a/odoo_tools/completions/fish/otools-project.fish
+++ b/odoo_tools/completions/fish/otools-project.fish
@@ -1,0 +1,17 @@
+function _otools_project_completion;
+    set -l response (env _OTOOLS_PROJECT_COMPLETE=fish_complete COMP_WORDS=(commandline -cp) COMP_CWORD=(commandline -t) otools-project);
+
+    for completion in $response;
+        set -l metadata (string split "," $completion);
+
+        if test $metadata[1] = "dir";
+            __fish_complete_directories $metadata[2];
+        else if test $metadata[1] = "file";
+            __fish_complete_path $metadata[2];
+        else if test $metadata[1] = "plain";
+            echo $metadata[2];
+        end;
+    end;
+end;
+
+complete --no-files --command otools-project --arguments "(_otools_project_completion)";

--- a/odoo_tools/completions/fish/otools-release.fish
+++ b/odoo_tools/completions/fish/otools-release.fish
@@ -1,0 +1,17 @@
+function _otools_release_completion;
+    set -l response (env _OTOOLS_RELEASE_COMPLETE=fish_complete COMP_WORDS=(commandline -cp) COMP_CWORD=(commandline -t) otools-release);
+
+    for completion in $response;
+        set -l metadata (string split "," $completion);
+
+        if test $metadata[1] = "dir";
+            __fish_complete_directories $metadata[2];
+        else if test $metadata[1] = "file";
+            __fish_complete_path $metadata[2];
+        else if test $metadata[1] = "plain";
+            echo $metadata[2];
+        end;
+    end;
+end;
+
+complete --no-files --command otools-release --arguments "(_otools_release_completion)";

--- a/odoo_tools/completions/fish/otools-submodule.fish
+++ b/odoo_tools/completions/fish/otools-submodule.fish
@@ -1,0 +1,17 @@
+function _otools_submodule_completion;
+    set -l response (env _OTOOLS_SUBMODULE_COMPLETE=fish_complete COMP_WORDS=(commandline -cp) COMP_CWORD=(commandline -t) otools-submodule);
+
+    for completion in $response;
+        set -l metadata (string split "," $completion);
+
+        if test $metadata[1] = "dir";
+            __fish_complete_directories $metadata[2];
+        else if test $metadata[1] = "file";
+            __fish_complete_path $metadata[2];
+        else if test $metadata[1] = "plain";
+            echo $metadata[2];
+        end;
+    end;
+end;
+
+complete --no-files --command otools-submodule --arguments "(_otools_submodule_completion)";

--- a/odoo_tools/completions/zsh/_otools-addon
+++ b/odoo_tools/completions/zsh/_otools-addon
@@ -1,0 +1,40 @@
+#compdef otools-addon
+
+_otools_addon_completion() {
+    local -a completions
+    local -a completions_with_descriptions
+    local -a response
+    (( ! $+commands[otools-addon] )) && return 1
+
+    response=("${(@f)$(env COMP_WORDS="${words[*]}" COMP_CWORD=$((CURRENT-1)) _OTOOLS_ADDON_COMPLETE=zsh_complete otools-addon)}")
+
+    for type key descr in ${response}; do
+        if [[ "$type" == "plain" ]]; then
+            if [[ "$descr" == "_" ]]; then
+                completions+=("$key")
+            else
+                completions_with_descriptions+=("$key":"$descr")
+            fi
+        elif [[ "$type" == "dir" ]]; then
+            _path_files -/
+        elif [[ "$type" == "file" ]]; then
+            _path_files -f
+        fi
+    done
+
+    if [ -n "$completions_with_descriptions" ]; then
+        _describe -V unsorted completions_with_descriptions -U
+    fi
+
+    if [ -n "$completions" ]; then
+        compadd -U -V unsorted -a completions
+    fi
+}
+
+if [[ $zsh_eval_context[-1] == loadautofunc ]]; then
+    # autoload from fpath, call function directly
+    _otools_addon_completion "$@"
+else
+    # eval/source/. command, register function for later
+    compdef _otools_addon_completion otools-addon
+fi

--- a/odoo_tools/completions/zsh/_otools-ba
+++ b/odoo_tools/completions/zsh/_otools-ba
@@ -1,0 +1,40 @@
+#compdef otools-ba
+
+_otools_ba_completion() {
+    local -a completions
+    local -a completions_with_descriptions
+    local -a response
+    (( ! $+commands[otools-ba] )) && return 1
+
+    response=("${(@f)$(env COMP_WORDS="${words[*]}" COMP_CWORD=$((CURRENT-1)) _OTOOLS_BA_COMPLETE=zsh_complete otools-ba)}")
+
+    for type key descr in ${response}; do
+        if [[ "$type" == "plain" ]]; then
+            if [[ "$descr" == "_" ]]; then
+                completions+=("$key")
+            else
+                completions_with_descriptions+=("$key":"$descr")
+            fi
+        elif [[ "$type" == "dir" ]]; then
+            _path_files -/
+        elif [[ "$type" == "file" ]]; then
+            _path_files -f
+        fi
+    done
+
+    if [ -n "$completions_with_descriptions" ]; then
+        _describe -V unsorted completions_with_descriptions -U
+    fi
+
+    if [ -n "$completions" ]; then
+        compadd -U -V unsorted -a completions
+    fi
+}
+
+if [[ $zsh_eval_context[-1] == loadautofunc ]]; then
+    # autoload from fpath, call function directly
+    _otools_ba_completion "$@"
+else
+    # eval/source/. command, register function for later
+    compdef _otools_ba_completion otools-ba
+fi

--- a/odoo_tools/completions/zsh/_otools-cloud
+++ b/odoo_tools/completions/zsh/_otools-cloud
@@ -1,0 +1,40 @@
+#compdef otools-cloud
+
+_otools_cloud_completion() {
+    local -a completions
+    local -a completions_with_descriptions
+    local -a response
+    (( ! $+commands[otools-cloud] )) && return 1
+
+    response=("${(@f)$(env COMP_WORDS="${words[*]}" COMP_CWORD=$((CURRENT-1)) _OTOOLS_CLOUD_COMPLETE=zsh_complete otools-cloud)}")
+
+    for type key descr in ${response}; do
+        if [[ "$type" == "plain" ]]; then
+            if [[ "$descr" == "_" ]]; then
+                completions+=("$key")
+            else
+                completions_with_descriptions+=("$key":"$descr")
+            fi
+        elif [[ "$type" == "dir" ]]; then
+            _path_files -/
+        elif [[ "$type" == "file" ]]; then
+            _path_files -f
+        fi
+    done
+
+    if [ -n "$completions_with_descriptions" ]; then
+        _describe -V unsorted completions_with_descriptions -U
+    fi
+
+    if [ -n "$completions" ]; then
+        compadd -U -V unsorted -a completions
+    fi
+}
+
+if [[ $zsh_eval_context[-1] == loadautofunc ]]; then
+    # autoload from fpath, call function directly
+    _otools_cloud_completion "$@"
+else
+    # eval/source/. command, register function for later
+    compdef _otools_cloud_completion otools-cloud
+fi

--- a/odoo_tools/completions/zsh/_otools-db
+++ b/odoo_tools/completions/zsh/_otools-db
@@ -1,0 +1,40 @@
+#compdef otools-db
+
+_otools_db_completion() {
+    local -a completions
+    local -a completions_with_descriptions
+    local -a response
+    (( ! $+commands[otools-db] )) && return 1
+
+    response=("${(@f)$(env COMP_WORDS="${words[*]}" COMP_CWORD=$((CURRENT-1)) _OTOOLS_DB_COMPLETE=zsh_complete otools-db)}")
+
+    for type key descr in ${response}; do
+        if [[ "$type" == "plain" ]]; then
+            if [[ "$descr" == "_" ]]; then
+                completions+=("$key")
+            else
+                completions_with_descriptions+=("$key":"$descr")
+            fi
+        elif [[ "$type" == "dir" ]]; then
+            _path_files -/
+        elif [[ "$type" == "file" ]]; then
+            _path_files -f
+        fi
+    done
+
+    if [ -n "$completions_with_descriptions" ]; then
+        _describe -V unsorted completions_with_descriptions -U
+    fi
+
+    if [ -n "$completions" ]; then
+        compadd -U -V unsorted -a completions
+    fi
+}
+
+if [[ $zsh_eval_context[-1] == loadautofunc ]]; then
+    # autoload from fpath, call function directly
+    _otools_db_completion "$@"
+else
+    # eval/source/. command, register function for later
+    compdef _otools_db_completion otools-db
+fi

--- a/odoo_tools/completions/zsh/_otools-i18n
+++ b/odoo_tools/completions/zsh/_otools-i18n
@@ -1,0 +1,40 @@
+#compdef otools-i18n
+
+_otools_i18n_completion() {
+    local -a completions
+    local -a completions_with_descriptions
+    local -a response
+    (( ! $+commands[otools-i18n] )) && return 1
+
+    response=("${(@f)$(env COMP_WORDS="${words[*]}" COMP_CWORD=$((CURRENT-1)) _OTOOLS_I18N_COMPLETE=zsh_complete otools-i18n)}")
+
+    for type key descr in ${response}; do
+        if [[ "$type" == "plain" ]]; then
+            if [[ "$descr" == "_" ]]; then
+                completions+=("$key")
+            else
+                completions_with_descriptions+=("$key":"$descr")
+            fi
+        elif [[ "$type" == "dir" ]]; then
+            _path_files -/
+        elif [[ "$type" == "file" ]]; then
+            _path_files -f
+        fi
+    done
+
+    if [ -n "$completions_with_descriptions" ]; then
+        _describe -V unsorted completions_with_descriptions -U
+    fi
+
+    if [ -n "$completions" ]; then
+        compadd -U -V unsorted -a completions
+    fi
+}
+
+if [[ $zsh_eval_context[-1] == loadautofunc ]]; then
+    # autoload from fpath, call function directly
+    _otools_i18n_completion "$@"
+else
+    # eval/source/. command, register function for later
+    compdef _otools_i18n_completion otools-i18n
+fi

--- a/odoo_tools/completions/zsh/_otools-migrate-db
+++ b/odoo_tools/completions/zsh/_otools-migrate-db
@@ -1,0 +1,40 @@
+#compdef otools-migrate-db
+
+_otools_migrate_db_completion() {
+    local -a completions
+    local -a completions_with_descriptions
+    local -a response
+    (( ! $+commands[otools-migrate-db] )) && return 1
+
+    response=("${(@f)$(env COMP_WORDS="${words[*]}" COMP_CWORD=$((CURRENT-1)) _OTOOLS_MIGRATE_DB_COMPLETE=zsh_complete otools-migrate-db)}")
+
+    for type key descr in ${response}; do
+        if [[ "$type" == "plain" ]]; then
+            if [[ "$descr" == "_" ]]; then
+                completions+=("$key")
+            else
+                completions_with_descriptions+=("$key":"$descr")
+            fi
+        elif [[ "$type" == "dir" ]]; then
+            _path_files -/
+        elif [[ "$type" == "file" ]]; then
+            _path_files -f
+        fi
+    done
+
+    if [ -n "$completions_with_descriptions" ]; then
+        _describe -V unsorted completions_with_descriptions -U
+    fi
+
+    if [ -n "$completions" ]; then
+        compadd -U -V unsorted -a completions
+    fi
+}
+
+if [[ $zsh_eval_context[-1] == loadautofunc ]]; then
+    # autoload from fpath, call function directly
+    _otools_migrate_db_completion "$@"
+else
+    # eval/source/. command, register function for later
+    compdef _otools_migrate_db_completion otools-migrate-db
+fi

--- a/odoo_tools/completions/zsh/_otools-password
+++ b/odoo_tools/completions/zsh/_otools-password
@@ -1,0 +1,40 @@
+#compdef otools-password
+
+_otools_password_completion() {
+    local -a completions
+    local -a completions_with_descriptions
+    local -a response
+    (( ! $+commands[otools-password] )) && return 1
+
+    response=("${(@f)$(env COMP_WORDS="${words[*]}" COMP_CWORD=$((CURRENT-1)) _OTOOLS_PASSWORD_COMPLETE=zsh_complete otools-password)}")
+
+    for type key descr in ${response}; do
+        if [[ "$type" == "plain" ]]; then
+            if [[ "$descr" == "_" ]]; then
+                completions+=("$key")
+            else
+                completions_with_descriptions+=("$key":"$descr")
+            fi
+        elif [[ "$type" == "dir" ]]; then
+            _path_files -/
+        elif [[ "$type" == "file" ]]; then
+            _path_files -f
+        fi
+    done
+
+    if [ -n "$completions_with_descriptions" ]; then
+        _describe -V unsorted completions_with_descriptions -U
+    fi
+
+    if [ -n "$completions" ]; then
+        compadd -U -V unsorted -a completions
+    fi
+}
+
+if [[ $zsh_eval_context[-1] == loadautofunc ]]; then
+    # autoload from fpath, call function directly
+    _otools_password_completion "$@"
+else
+    # eval/source/. command, register function for later
+    compdef _otools_password_completion otools-password
+fi

--- a/odoo_tools/completions/zsh/_otools-pending
+++ b/odoo_tools/completions/zsh/_otools-pending
@@ -1,0 +1,40 @@
+#compdef otools-pending
+
+_otools_pending_completion() {
+    local -a completions
+    local -a completions_with_descriptions
+    local -a response
+    (( ! $+commands[otools-pending] )) && return 1
+
+    response=("${(@f)$(env COMP_WORDS="${words[*]}" COMP_CWORD=$((CURRENT-1)) _OTOOLS_PENDING_COMPLETE=zsh_complete otools-pending)}")
+
+    for type key descr in ${response}; do
+        if [[ "$type" == "plain" ]]; then
+            if [[ "$descr" == "_" ]]; then
+                completions+=("$key")
+            else
+                completions_with_descriptions+=("$key":"$descr")
+            fi
+        elif [[ "$type" == "dir" ]]; then
+            _path_files -/
+        elif [[ "$type" == "file" ]]; then
+            _path_files -f
+        fi
+    done
+
+    if [ -n "$completions_with_descriptions" ]; then
+        _describe -V unsorted completions_with_descriptions -U
+    fi
+
+    if [ -n "$completions" ]; then
+        compadd -U -V unsorted -a completions
+    fi
+}
+
+if [[ $zsh_eval_context[-1] == loadautofunc ]]; then
+    # autoload from fpath, call function directly
+    _otools_pending_completion "$@"
+else
+    # eval/source/. command, register function for later
+    compdef _otools_pending_completion otools-pending
+fi

--- a/odoo_tools/completions/zsh/_otools-pr
+++ b/odoo_tools/completions/zsh/_otools-pr
@@ -1,0 +1,40 @@
+#compdef otools-pr
+
+_otools_pr_completion() {
+    local -a completions
+    local -a completions_with_descriptions
+    local -a response
+    (( ! $+commands[otools-pr] )) && return 1
+
+    response=("${(@f)$(env COMP_WORDS="${words[*]}" COMP_CWORD=$((CURRENT-1)) _OTOOLS_PR_COMPLETE=zsh_complete otools-pr)}")
+
+    for type key descr in ${response}; do
+        if [[ "$type" == "plain" ]]; then
+            if [[ "$descr" == "_" ]]; then
+                completions+=("$key")
+            else
+                completions_with_descriptions+=("$key":"$descr")
+            fi
+        elif [[ "$type" == "dir" ]]; then
+            _path_files -/
+        elif [[ "$type" == "file" ]]; then
+            _path_files -f
+        fi
+    done
+
+    if [ -n "$completions_with_descriptions" ]; then
+        _describe -V unsorted completions_with_descriptions -U
+    fi
+
+    if [ -n "$completions" ]; then
+        compadd -U -V unsorted -a completions
+    fi
+}
+
+if [[ $zsh_eval_context[-1] == loadautofunc ]]; then
+    # autoload from fpath, call function directly
+    _otools_pr_completion "$@"
+else
+    # eval/source/. command, register function for later
+    compdef _otools_pr_completion otools-pr
+fi

--- a/odoo_tools/completions/zsh/_otools-project
+++ b/odoo_tools/completions/zsh/_otools-project
@@ -1,0 +1,40 @@
+#compdef otools-project
+
+_otools_project_completion() {
+    local -a completions
+    local -a completions_with_descriptions
+    local -a response
+    (( ! $+commands[otools-project] )) && return 1
+
+    response=("${(@f)$(env COMP_WORDS="${words[*]}" COMP_CWORD=$((CURRENT-1)) _OTOOLS_PROJECT_COMPLETE=zsh_complete otools-project)}")
+
+    for type key descr in ${response}; do
+        if [[ "$type" == "plain" ]]; then
+            if [[ "$descr" == "_" ]]; then
+                completions+=("$key")
+            else
+                completions_with_descriptions+=("$key":"$descr")
+            fi
+        elif [[ "$type" == "dir" ]]; then
+            _path_files -/
+        elif [[ "$type" == "file" ]]; then
+            _path_files -f
+        fi
+    done
+
+    if [ -n "$completions_with_descriptions" ]; then
+        _describe -V unsorted completions_with_descriptions -U
+    fi
+
+    if [ -n "$completions" ]; then
+        compadd -U -V unsorted -a completions
+    fi
+}
+
+if [[ $zsh_eval_context[-1] == loadautofunc ]]; then
+    # autoload from fpath, call function directly
+    _otools_project_completion "$@"
+else
+    # eval/source/. command, register function for later
+    compdef _otools_project_completion otools-project
+fi

--- a/odoo_tools/completions/zsh/_otools-release
+++ b/odoo_tools/completions/zsh/_otools-release
@@ -1,0 +1,40 @@
+#compdef otools-release
+
+_otools_release_completion() {
+    local -a completions
+    local -a completions_with_descriptions
+    local -a response
+    (( ! $+commands[otools-release] )) && return 1
+
+    response=("${(@f)$(env COMP_WORDS="${words[*]}" COMP_CWORD=$((CURRENT-1)) _OTOOLS_RELEASE_COMPLETE=zsh_complete otools-release)}")
+
+    for type key descr in ${response}; do
+        if [[ "$type" == "plain" ]]; then
+            if [[ "$descr" == "_" ]]; then
+                completions+=("$key")
+            else
+                completions_with_descriptions+=("$key":"$descr")
+            fi
+        elif [[ "$type" == "dir" ]]; then
+            _path_files -/
+        elif [[ "$type" == "file" ]]; then
+            _path_files -f
+        fi
+    done
+
+    if [ -n "$completions_with_descriptions" ]; then
+        _describe -V unsorted completions_with_descriptions -U
+    fi
+
+    if [ -n "$completions" ]; then
+        compadd -U -V unsorted -a completions
+    fi
+}
+
+if [[ $zsh_eval_context[-1] == loadautofunc ]]; then
+    # autoload from fpath, call function directly
+    _otools_release_completion "$@"
+else
+    # eval/source/. command, register function for later
+    compdef _otools_release_completion otools-release
+fi

--- a/odoo_tools/completions/zsh/_otools-submodule
+++ b/odoo_tools/completions/zsh/_otools-submodule
@@ -1,0 +1,40 @@
+#compdef otools-submodule
+
+_otools_submodule_completion() {
+    local -a completions
+    local -a completions_with_descriptions
+    local -a response
+    (( ! $+commands[otools-submodule] )) && return 1
+
+    response=("${(@f)$(env COMP_WORDS="${words[*]}" COMP_CWORD=$((CURRENT-1)) _OTOOLS_SUBMODULE_COMPLETE=zsh_complete otools-submodule)}")
+
+    for type key descr in ${response}; do
+        if [[ "$type" == "plain" ]]; then
+            if [[ "$descr" == "_" ]]; then
+                completions+=("$key")
+            else
+                completions_with_descriptions+=("$key":"$descr")
+            fi
+        elif [[ "$type" == "dir" ]]; then
+            _path_files -/
+        elif [[ "$type" == "file" ]]; then
+            _path_files -f
+        fi
+    done
+
+    if [ -n "$completions_with_descriptions" ]; then
+        _describe -V unsorted completions_with_descriptions -U
+    fi
+
+    if [ -n "$completions" ]; then
+        compadd -U -V unsorted -a completions
+    fi
+}
+
+if [[ $zsh_eval_context[-1] == loadautofunc ]]; then
+    # autoload from fpath, call function directly
+    _otools_submodule_completion "$@"
+else
+    # eval/source/. command, register function for later
+    compdef _otools_submodule_completion otools-submodule
+fi

--- a/odoo_tools/utils/completion.py
+++ b/odoo_tools/utils/completion.py
@@ -1,0 +1,226 @@
+# Copyright 2026 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+
+from __future__ import annotations
+
+import io
+import os
+import re
+from contextlib import redirect_stdout
+from importlib import import_module
+from importlib.resources import files
+from pathlib import Path
+
+SHELLS = ("bash", "zsh", "fish")
+
+
+def read_project_scripts(pyproject_path: Path) -> dict[str, str]:
+    """Read [project.scripts] from pyproject.toml without extra deps."""
+    content = pyproject_path.read_text()
+    in_scripts = False
+    scripts: dict[str, str] = {}
+    for line in content.splitlines():
+        stripped = line.strip()
+        if stripped == "[project.scripts]":
+            in_scripts = True
+            continue
+        if in_scripts and stripped.startswith("["):
+            break
+        if not in_scripts or not stripped or stripped.startswith("#"):
+            continue
+        match = re.match(r'([A-Za-z0-9_-]+)\s*=\s*"([^"]+)"', stripped)
+        if match:
+            scripts[match.group(1)] = match.group(2)
+    if not scripts:
+        raise RuntimeError("No [project.scripts] entry found in pyproject.toml")
+    return scripts
+
+
+def _load_click_command(import_path: str):
+    module_name, attr_name = import_path.rsplit(":", 1)
+    module = import_module(module_name)
+    command = getattr(module, attr_name)
+    return command
+
+
+def _complete_var_name(prog_name: str) -> str:
+    return f"_{prog_name.replace('-', '_').upper()}_COMPLETE"
+
+
+def _render_shell_source(prog_name: str, import_path: str, shell: str) -> str:
+    command = _load_click_command(import_path)
+    complete_var = _complete_var_name(prog_name)
+    stdout_buffer = io.BytesIO()
+    stdout = io.TextIOWrapper(stdout_buffer, encoding="utf-8")
+    previous = os.environ.get(complete_var)
+    previous_skip_update = os.environ.get("OTOOLS_SKIP_UPDATE_CHECK")
+    with redirect_stdout(stdout):
+        os.environ[complete_var] = f"{shell}_source"
+        os.environ["OTOOLS_SKIP_UPDATE_CHECK"] = "1"
+        try:
+            try:
+                command.main(args=[], prog_name=prog_name, standalone_mode=False)
+            except SystemExit as exc:
+                if exc.code not in (0, None):
+                    raise
+        finally:
+            if previous is None:
+                os.environ.pop(complete_var, None)
+            else:
+                os.environ[complete_var] = previous
+            if previous_skip_update is None:
+                os.environ.pop("OTOOLS_SKIP_UPDATE_CHECK", None)
+            else:
+                os.environ["OTOOLS_SKIP_UPDATE_CHECK"] = previous_skip_update
+    stdout.flush()
+    source = stdout_buffer.getvalue().decode("utf-8")
+    if not source.strip():
+        raise RuntimeError(f"Empty completion source for {prog_name} ({shell})")
+    return source
+
+
+def completion_file_name(prog_name: str, shell: str) -> str:
+    if shell == "bash":
+        return prog_name
+    if shell == "zsh":
+        return f"_{prog_name}"
+    if shell == "fish":
+        return f"{prog_name}.fish"
+    raise ValueError(f"Unsupported shell: {shell}")
+
+
+def generate_completion_files(
+    scripts: dict[str, str],
+    output_dir: Path,
+    shells: tuple[str, ...] = SHELLS,
+) -> list[Path]:
+    written: list[Path] = []
+    for shell in shells:
+        shell_dir = output_dir / shell
+        shell_dir.mkdir(parents=True, exist_ok=True)
+        for prog_name, import_path in sorted(scripts.items()):
+            file_path = shell_dir / completion_file_name(prog_name, shell)
+            source = _render_shell_source(prog_name, import_path, shell)
+            if not source.endswith("\n"):
+                source += "\n"
+            file_path.write_text(source)
+            written.append(file_path)
+    return written
+
+
+def project_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def completion_output_dir(root: Path) -> Path:
+    return root / "odoo_tools" / "completions"
+
+
+def main() -> int:
+    root = project_root()
+    scripts = read_project_scripts(root / "pyproject.toml")
+    written = generate_completion_files(scripts, completion_output_dir(root))
+    print(f"Generated {len(written)} completion files.")
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# Shell setup helpers (used by otools-setup)
+# ---------------------------------------------------------------------------
+
+BLOCK_BEGIN = "# BEGIN otools-setup"
+BLOCK_END = "# END otools-setup"
+
+#: Supported shells and their default RC file (None = fish, handled separately)
+SHELL_RC_FILES: dict[str, str] = {
+    "bash": "~/.bashrc",
+    "zsh": "~/.zshrc",
+}
+
+
+def installed_completions_dir() -> Path:
+    """Return the Path of the installed package-data completion directory."""
+    return Path(str(files("odoo_tools.completions")))
+
+
+def detect_shell() -> str | None:
+    """Return the name of the current shell (bash/zsh/fish) or None."""
+    shell_env = os.environ.get("SHELL", "")
+    name = Path(shell_env).name.lower()
+    if name in SHELLS:
+        return name
+    return None
+
+
+def shell_rc_file(shell: str) -> Path | None:
+    """Return the Path to the shell startup file, or None for fish (no RC needed)."""
+    rc = SHELL_RC_FILES.get(shell)
+    if rc is None:
+        return None
+    return Path(rc).expanduser()
+
+
+def build_completion_block(shell: str, completions_dir: Path) -> str:
+    """Build the marked completion block to insert into a shell RC file.
+
+    Returns the full block text including surrounding blank lines but *without*
+    a trailing newline — callers decide how to join it.
+    """
+    dir_str = str(completions_dir)
+    if shell == "bash":
+        snippet = (
+            f'OTOOLS_COMPLETIONS_DIR="{dir_str}"\n'
+            'for f in "$OTOOLS_COMPLETIONS_DIR"/bash/*; do\n'
+            "  # shellcheck disable=SC1090\n"
+            '  source "$f"\n'
+            "done"
+        )
+    elif shell == "zsh":
+        snippet = f'fpath=("{dir_str}/zsh" $fpath)\nautoload -Uz compinit\ncompinit'
+    else:
+        raise ValueError(f"build_completion_block: unsupported shell {shell!r}")
+    return f"{BLOCK_BEGIN}\n{snippet}\n{BLOCK_END}"
+
+
+def fish_completions_dir() -> Path:
+    """Return the default fish completions directory."""
+    return Path("~/.config/fish/completions").expanduser()
+
+
+def update_rc_content(existing_content: str, shell: str, completions_dir: Path) -> str:
+    """Return the new RC-file content with the otools block inserted or replaced.
+
+    If a marked block already exists it is replaced in-place.  Otherwise the
+    block is appended at the end, separated by a blank line.
+    """
+    block = build_completion_block(shell, completions_dir)
+    pattern = re.compile(
+        rf"^{re.escape(BLOCK_BEGIN)}.*?^{re.escape(BLOCK_END)}",
+        re.MULTILINE | re.DOTALL,
+    )
+    if pattern.search(existing_content):
+        return pattern.sub(block, existing_content)
+    # Append with a leading blank line if the file doesn't already end with one.
+    separator = "" if existing_content.endswith("\n\n") else "\n"
+    if not existing_content.endswith("\n"):
+        separator = "\n" + separator
+    return existing_content + separator + block + "\n"
+
+
+def diff_rc_content(original: str, updated: str, rc_path: Path) -> str:
+    """Return a unified-diff-style string showing the proposed RC-file change."""
+    import difflib
+
+    original_lines = original.splitlines(keepends=True)
+    updated_lines = updated.splitlines(keepends=True)
+    diff = difflib.unified_diff(
+        original_lines,
+        updated_lines,
+        fromfile=str(rc_path),
+        tofile=str(rc_path),
+    )
+    return "".join(diff)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ otools-db = "odoo_tools.cli.db:cli"
 otools-cloud = "odoo_tools.cli.cloud:cli"
 otools-i18n = "odoo_tools.cli.i18n:cli"
 otools-password = "odoo_tools.cli.password:cli"
+otools-setup = "odoo_tools.cli.setup:cli"
 
 
 [project.optional-dependencies]
@@ -75,10 +76,14 @@ source = "vcs"
 
 [tool.hatch.build.targets.wheel]
 packages = ["odoo_tools"]
+include = [
+    "odoo_tools/completions/**",
+]
 
 [tool.hatch.build.targets.sdist]
 include = [
     "odoo_tools",
+    "odoo_tools/completions/**",
     "LICENSE",
     "README.md",
 ]

--- a/scripts/generate_completions.py
+++ b/scripts/generate_completions.py
@@ -1,0 +1,6 @@
+#!/usr/bin/env python3
+
+from odoo_tools.utils.completion import main
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -1,0 +1,297 @@
+# Copyright 2026 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+"""Tests for otools-setup and the completion setup helpers."""
+
+from pathlib import Path
+from unittest import mock
+
+import pytest
+from click.testing import CliRunner
+
+from odoo_tools.cli.setup import cli
+from odoo_tools.utils.completion import (
+    BLOCK_BEGIN,
+    BLOCK_END,
+    build_completion_block,
+    detect_shell,
+    diff_rc_content,
+    installed_completions_dir,
+    shell_rc_file,
+    update_rc_content,
+)
+
+# ---------------------------------------------------------------------------
+# detect_shell
+# ---------------------------------------------------------------------------
+
+
+def test_detect_shell_bash():
+    with mock.patch.dict("os.environ", {"SHELL": "/bin/bash"}):
+        assert detect_shell() == "bash"
+
+
+def test_detect_shell_zsh():
+    with mock.patch.dict("os.environ", {"SHELL": "/usr/bin/zsh"}):
+        assert detect_shell() == "zsh"
+
+
+def test_detect_shell_fish():
+    with mock.patch.dict("os.environ", {"SHELL": "/usr/bin/fish"}):
+        assert detect_shell() == "fish"
+
+
+def test_detect_shell_unknown():
+    with mock.patch.dict("os.environ", {"SHELL": "/bin/sh"}):
+        assert detect_shell() is None
+
+
+def test_detect_shell_missing():
+    env = {k: v for k, v in __import__("os").environ.items() if k != "SHELL"}
+    with mock.patch.dict("os.environ", env, clear=True):
+        assert detect_shell() is None
+
+
+# ---------------------------------------------------------------------------
+# shell_rc_file
+# ---------------------------------------------------------------------------
+
+
+def test_shell_rc_file_bash():
+    path = shell_rc_file("bash")
+    assert path is not None
+    assert path.name == ".bashrc"
+
+
+def test_shell_rc_file_zsh():
+    path = shell_rc_file("zsh")
+    assert path is not None
+    assert path.name == ".zshrc"
+
+
+def test_shell_rc_file_fish_is_none():
+    """Fish does not use an RC-file for completion; should return None."""
+    assert shell_rc_file("fish") is None
+
+
+# ---------------------------------------------------------------------------
+# build_completion_block
+# ---------------------------------------------------------------------------
+
+
+def test_build_completion_block_bash_contains_markers(tmp_path):
+    block = build_completion_block("bash", tmp_path / "completions")
+    assert BLOCK_BEGIN in block
+    assert BLOCK_END in block
+
+
+def test_build_completion_block_bash_snippet(tmp_path):
+    completions_dir = tmp_path / "completions"
+    block = build_completion_block("bash", completions_dir)
+    assert str(completions_dir) in block
+    assert "source" in block
+
+
+def test_build_completion_block_zsh_snippet(tmp_path):
+    completions_dir = tmp_path / "completions"
+    block = build_completion_block("zsh", completions_dir)
+    assert str(completions_dir) in block
+    assert "fpath" in block
+    assert "compinit" in block
+
+
+def test_build_completion_block_unsupported_shell(tmp_path):
+    with pytest.raises(ValueError, match="unsupported shell"):
+        build_completion_block("fish", tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# update_rc_content — append when block missing
+# ---------------------------------------------------------------------------
+
+
+def test_update_rc_content_appends_block(tmp_path):
+    existing = "# existing content\nexport FOO=bar\n"
+    updated = update_rc_content(existing, "bash", tmp_path / "completions")
+    assert BLOCK_BEGIN in updated
+    assert BLOCK_END in updated
+    # Original content preserved
+    assert "# existing content" in updated
+
+
+def test_update_rc_content_append_has_separator(tmp_path):
+    existing = "export FOO=bar\n"
+    updated = update_rc_content(existing, "bash", tmp_path / "completions")
+    # Block must not be glued directly to existing content without a newline
+    idx_end = updated.rfind("export FOO=bar")
+    idx_begin = updated.find(BLOCK_BEGIN)
+    between = updated[idx_end + len("export FOO=bar") : idx_begin]
+    assert "\n" in between
+
+
+# ---------------------------------------------------------------------------
+# update_rc_content — idempotency
+# ---------------------------------------------------------------------------
+
+
+def test_update_rc_content_idempotent(tmp_path):
+    completions_dir = tmp_path / "completions"
+    existing = "export FOO=bar\n"
+    first = update_rc_content(existing, "bash", completions_dir)
+    second = update_rc_content(first, "bash", completions_dir)
+    assert first == second
+
+
+def test_update_rc_content_replaces_existing_block(tmp_path):
+    old_dir = tmp_path / "old_completions"
+    new_dir = tmp_path / "new_completions"
+    existing = "export FOO=bar\n" + build_completion_block("bash", old_dir) + "\n"
+    updated = update_rc_content(existing, "bash", new_dir)
+    assert str(new_dir) in updated
+    assert str(old_dir) not in updated
+    # Only one block present
+    assert updated.count(BLOCK_BEGIN) == 1
+
+
+# ---------------------------------------------------------------------------
+# diff_rc_content
+# ---------------------------------------------------------------------------
+
+
+def test_diff_rc_content_shows_diff(tmp_path):
+    rc = tmp_path / ".bashrc"
+    original = "# existing\n"
+    updated = original + build_completion_block("bash", tmp_path / "completions") + "\n"
+    diff = diff_rc_content(original, updated, rc)
+    assert diff  # non-empty
+    assert BLOCK_BEGIN in diff
+
+
+def test_diff_rc_content_empty_when_no_change(tmp_path):
+    rc = tmp_path / ".bashrc"
+    content = "# no changes\n"
+    diff = diff_rc_content(content, content, rc)
+    assert diff == ""
+
+
+# ---------------------------------------------------------------------------
+# installed_completions_dir
+# ---------------------------------------------------------------------------
+
+
+def test_installed_completions_dir_is_path():
+    path = installed_completions_dir()
+    assert isinstance(path, Path)
+
+
+def test_installed_completions_dir_contains_bash():
+    path = installed_completions_dir()
+    # The bash subdirectory must exist in a properly installed package
+    bash_dir = path / "bash"
+    assert bash_dir.exists(), f"Expected bash completion dir at {bash_dir}"
+
+
+# ---------------------------------------------------------------------------
+# CLI — shell-completion command (bash)
+# ---------------------------------------------------------------------------
+
+
+def test_cli_shell_completion_bash_preview_and_approve(tmp_path, monkeypatch):
+    rc_file = tmp_path / ".bashrc"
+    rc_file.write_text("# existing\n")
+    completions_dir = installed_completions_dir()
+
+    monkeypatch.setattr(
+        "odoo_tools.cli.setup.installed_completions_dir", lambda: completions_dir
+    )
+    monkeypatch.setattr("odoo_tools.cli.setup.shell_rc_file", lambda shell: rc_file)
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["shell-completion", "--shell", "bash"], input="y\n")
+    assert result.exit_code == 0, result.output
+    content = rc_file.read_text()
+    assert BLOCK_BEGIN in content
+    assert BLOCK_END in content
+
+
+def test_cli_shell_completion_bash_abort(tmp_path, monkeypatch):
+    rc_file = tmp_path / ".bashrc"
+    rc_file.write_text("# existing\n")
+
+    monkeypatch.setattr(
+        "odoo_tools.cli.setup.installed_completions_dir",
+        lambda: tmp_path / "completions",
+    )
+    monkeypatch.setattr("odoo_tools.cli.setup.shell_rc_file", lambda shell: rc_file)
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["shell-completion", "--shell", "bash"], input="n\n")
+    # Abort exits with non-zero
+    assert result.exit_code != 0
+    # RC file must be unchanged
+    assert rc_file.read_text() == "# existing\n"
+
+
+def test_cli_shell_completion_no_op_when_already_configured(tmp_path, monkeypatch):
+    completions_dir = installed_completions_dir()
+    existing = build_completion_block("bash", completions_dir) + "\n"
+    rc_file = tmp_path / ".bashrc"
+    rc_file.write_text(existing)
+
+    monkeypatch.setattr(
+        "odoo_tools.cli.setup.installed_completions_dir", lambda: completions_dir
+    )
+    monkeypatch.setattr("odoo_tools.cli.setup.shell_rc_file", lambda shell: rc_file)
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["shell-completion", "--shell", "bash"])
+    assert result.exit_code == 0
+    assert "already up to date" in result.output
+
+
+def test_cli_shell_completion_unknown_shell_env_error(monkeypatch):
+    monkeypatch.delenv("SHELL", raising=False)
+    runner = CliRunner()
+    result = runner.invoke(cli, ["shell-completion"])
+    assert result.exit_code != 0
+    assert "Could not detect" in result.output or "Error" in result.output
+
+
+# ---------------------------------------------------------------------------
+# CLI — shell-completion command (fish)
+# ---------------------------------------------------------------------------
+
+
+def test_cli_shell_completion_fish_copies_files(tmp_path, monkeypatch):
+    completions_dir = installed_completions_dir()
+    fish_target = tmp_path / "fish" / "completions"
+
+    monkeypatch.setattr(
+        "odoo_tools.cli.setup.installed_completions_dir", lambda: completions_dir
+    )
+    monkeypatch.setattr(
+        "odoo_tools.cli.setup.fish_completions_dir", lambda: fish_target
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["shell-completion", "--shell", "fish"], input="y\n")
+    assert result.exit_code == 0, result.output
+    assert fish_target.exists()
+    fish_files = list(fish_target.glob("*.fish"))
+    assert fish_files, "Expected fish completion files to be copied"
+
+
+def test_cli_shell_completion_fish_abort(tmp_path, monkeypatch):
+    completions_dir = installed_completions_dir()
+    fish_target = tmp_path / "fish" / "completions"
+
+    monkeypatch.setattr(
+        "odoo_tools.cli.setup.installed_completions_dir", lambda: completions_dir
+    )
+    monkeypatch.setattr(
+        "odoo_tools.cli.setup.fish_completions_dir", lambda: fish_target
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["shell-completion", "--shell", "fish"], input="n\n")
+    assert result.exit_code != 0
+    assert not fish_target.exists() or not list(fish_target.glob("*.fish"))

--- a/tests/test_utils_completion.py
+++ b/tests/test_utils_completion.py
@@ -1,0 +1,52 @@
+# Copyright 2026 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+
+from pathlib import Path
+
+from odoo_tools.utils.completion import (
+    SHELLS,
+    completion_file_name,
+    generate_completion_files,
+    read_project_scripts,
+)
+
+
+def test_read_project_scripts_contains_otools_commands():
+    pyproject = Path(__file__).resolve().parents[1] / "pyproject.toml"
+    scripts = read_project_scripts(pyproject)
+    assert "otools-project" in scripts
+    assert "otools-password" in scripts
+    assert "otools-setup" in scripts
+    assert len(scripts) == 13
+
+
+def test_generate_completion_files_for_all_scripts(tmp_path):
+    pyproject = Path(__file__).resolve().parents[1] / "pyproject.toml"
+    scripts = read_project_scripts(pyproject)
+
+    written = generate_completion_files(scripts, tmp_path)
+
+    assert len(written) == len(scripts) * len(SHELLS)
+
+    for prog_name in scripts:
+        bash_file = tmp_path / "bash" / completion_file_name(prog_name, "bash")
+        zsh_file = tmp_path / "zsh" / completion_file_name(prog_name, "zsh")
+        fish_file = tmp_path / "fish" / completion_file_name(prog_name, "fish")
+
+        assert bash_file.exists()
+        assert zsh_file.exists()
+        assert fish_file.exists()
+
+        complete_var = f"_{prog_name.replace('-', '_').upper()}_COMPLETE"
+
+        bash_content = bash_file.read_text()
+        zsh_content = zsh_file.read_text()
+        fish_content = fish_file.read_text()
+
+        assert complete_var in bash_content
+        assert complete_var in zsh_content
+        assert complete_var in fish_content
+
+        assert prog_name in bash_content
+        assert prog_name in zsh_content
+        assert prog_name in fish_content


### PR DESCRIPTION
The tab completion on the command line is added for bash, zsh and fish using the built in click feature.

A new command otools-setup is added to help the user install or update the configuration on their machine.