### PR TITLE
[IMP] pending: allow 'add' to take multiple URLs at once

### DIFF
--- a/odoo_tools/cli/pending.py
+++ b/odoo_tools/cli/pending.py
@@ -239,7 +239,7 @@ def aggregate(repo_path, target_branch=None, push=None):
 
 
 @cli.command(name="add")
-@click.argument("entity_url")
+@click.argument("entity_urls", nargs=-1, required=True)
 @click.option(
     "--aggregate/--no-aggregate",
     "aggregate",
@@ -262,13 +262,26 @@ def aggregate(repo_path, target_branch=None, push=None):
     default=True,
     help="push the result of the aggregation to a remote branch",
 )
-def add_pending(entity_url, aggregate=True, patch=False, push=True):
-    """Add a pending merge using given entity link"""
+def add_pending(entity_urls, aggregate=True, patch=False, push=True):
+    """Add one or more pending merges using the given entity link(s)"""
     # pattern, given an https://github.com/<user>/<repo>/pull/<pr-index>
     # # PR headline
     # # PR link as is
     # - refs/pull/<pr-index>/head
-    pm_utils.add_pending(entity_url, aggregate=aggregate, patch=patch, push=push)
+    # Add every pending merge to its file first, without aggregating, and
+    # collect the affected repos deduplicated by their merges file so that a
+    # submodule referenced by several URLs is aggregated only once.
+    repos = {}
+    for entity_url in entity_urls:
+        repo = pm_utils.add_pending(entity_url, aggregate=False, patch=patch)
+        repos[repo.abs_merges_path] = repo
+    # Then aggregate each affected submodule once.
+    if aggregate:
+        for repo in repos.values():
+            aggregator = repo.get_aggregator()
+            aggregator.aggregate()
+            if push:
+                aggregator.push()
 
 
 @cli.command(name="remove")

--- a/tests/test_utils_pending_merge.py
+++ b/tests/test_utils_pending_merge.py
@@ -10,6 +10,7 @@ import requests
 import responses
 from git.config import GitConfigParser
 
+from odoo_tools.cli import pending
 from odoo_tools.exceptions import Exit, PathNotFound
 from odoo_tools.utils import pending_merge as pm_utils
 from odoo_tools.utils.config import config
@@ -715,6 +716,86 @@ def test_add_pending_pull_request_patch():
     line_tmpl = "curl -sSL https://github.com/OCA/edi/pull/{}.patch | git am -3 --keep-non-patch --exclude '*requirements.txt'"
     for pid in (1470, 1471):
         assert line_tmpl.format(pid) in shell_command_after, shell_command_after
+
+
+def test_cli_add_multiple_urls(project):
+    """`otools-pending add` accepts several URLs at once, writing every entry to
+    its merges file. URLs for the same submodule land in the same file."""
+    mock_pending_merge_repo_paths("edi")
+    mock_pending_merge_repo_paths("web")
+    edi = Repo("edi", path_check=False)
+    web = Repo("web", path_check=False)
+    with responses.RequestsMock() as rsps:
+        # match the project's odoo_version so no divergent-branch prompt
+        for pull_id in (1470, 1471):
+            rsps.add(
+                responses.GET,
+                f"https://api.github.com/repos/OCA/edi/pulls/{pull_id}",
+                json={"base": {"ref": "14.0"}},
+                status=200,
+            )
+        rsps.add(
+            responses.GET,
+            "https://api.github.com/repos/OCA/web/pulls/2000",
+            json={"base": {"ref": "14.0"}},
+            status=200,
+        )
+        result = project.invoke(
+            pending.add_pending,
+            [
+                "https://github.com/OCA/edi/pull/1470",
+                "https://github.com/OCA/edi/pull/1471",
+                "https://github.com/OCA/web/pull/2000",
+                "--no-aggregate",
+            ],
+            catch_exceptions=False,
+        )
+    assert result.exit_code == 0
+    edi_merges = edi.merges_config()["merges"]
+    assert "OCA refs/pull/1470/head" in edi_merges
+    assert "OCA refs/pull/1471/head" in edi_merges
+    web_merges = web.merges_config()["merges"]
+    assert "OCA refs/pull/2000/head" in web_merges
+
+
+def test_cli_add_multiple_urls_aggregates_once_per_submodule(project):
+    """Submodules are aggregated once each, after all entries are written, even
+    when several URLs target the same submodule (no intermediate aggregation)."""
+    mock_pending_merge_repo_paths("edi")
+    mock_pending_merge_repo_paths("web")
+    aggregator = mock.MagicMock()
+    with responses.RequestsMock() as rsps:
+        # match the project's odoo_version so no divergent-branch prompt
+        for pull_id in (1470, 1471):
+            rsps.add(
+                responses.GET,
+                f"https://api.github.com/repos/OCA/edi/pulls/{pull_id}",
+                json={"base": {"ref": "14.0"}},
+                status=200,
+            )
+        rsps.add(
+            responses.GET,
+            "https://api.github.com/repos/OCA/web/pulls/2000",
+            json={"base": {"ref": "14.0"}},
+            status=200,
+        )
+        with mock.patch.object(
+            pm_utils.Repo, "get_aggregator", return_value=aggregator
+        ) as get_aggregator:
+            result = project.invoke(
+                pending.add_pending,
+                [
+                    "https://github.com/OCA/edi/pull/1470",
+                    "https://github.com/OCA/edi/pull/1471",
+                    "https://github.com/OCA/web/pull/2000",
+                ],
+                catch_exceptions=False,
+            )
+    assert result.exit_code == 0
+    # edi is referenced twice but aggregated once: 2 unique submodules total.
+    assert get_aggregator.call_count == 2
+    assert aggregator.aggregate.call_count == 2
+    assert aggregator.push.call_count == 2
 
 
 def test_iter_pending_pull_requests(project):


### PR DESCRIPTION
## What

`otools-pending add` can now take **several URLs at once**:

```sh
otools-pending add URL1 URL2 URL3 ...
```

Previously it accepted only one URL per run, so adding multiple pending merges meant running the command once per URL.

## Why

When you run the command once per URL, **each run aggregates and pushes** the affected submodule. If two URLs point at the *same* submodule, that submodule gets aggregated and pushed twice — slow and wasteful.

## How it works

The URLs can belong to different submodules or the same one. The command now:

1. Writes **every** pending merge into its respective merges file first (no aggregation yet).
2. Then aggregates each affected submodule **exactly once** at the end (and pushes once).

So a submodule referenced by several URLs is aggregated a single time instead of once per URL — no more intermediate aggregations.

The `--patch`, `--aggregate/--no-aggregate` and `--push/--no-push` flags keep their current meaning and apply to all URLs in the invocation.

## Notes

- The low-level `pm_utils.add_pending()` helper is unchanged; the multi-URL orchestration lives in the CLI command (consistent with the existing `aggregate` command).
- Added CLI-level tests covering multiple URLs across the same and different submodules, including a test asserting each submodule is aggregated only once.
