### PR TITLE
[IMP] release: automate commit, tag and branch push in otools-release bump

### DIFF
--- a/odoo_tools/cli/release.py
+++ b/odoo_tools/cli/release.py
@@ -109,6 +109,43 @@ def _warn_deprecated_bumpversion_cfg():
         )
 
 
+def _do_bump(rel_type, new_version=None):
+    """Run the file-modifying release steps.
+
+    Bumps the version, regenerates the changelog (towncrier) and updates the
+    marabunta migration file. Does not touch git: staging, commit, tag and push
+    are left to the caller. Returns the new version and the list of files the
+    release process modified.
+    """
+    # Obtain the list of files where a version is written
+    files = get_bumpversion_files()
+    if not files:
+        raise click.ClickException(
+            "No files to bump. Configure a VERSION file or create a bundle addon."
+        )
+    modified = []
+    # Run bumpversion
+    current_version = get_current_version()
+    cmd = make_bumpversion_cmd(
+        rel_type, current_version, files, new_version=new_version
+    )
+    run(cmd, check=True, verbose=True)
+    modified.extend(files)
+    new_version = get_current_version()
+    # Run towncrier. It rewrites HISTORY.rst and consumes the fragments in changes.d
+    run(make_towncrier_cmd(new_version), check=True, verbose=True)
+    modified.extend(
+        [
+            build_path("HISTORY.rst").as_posix(),
+            build_path("changes.d").as_posix(),
+        ]
+    )
+    if config.marabunta_mig_file_rel_path:
+        update_marabunta_file(new_version)
+        modified.append(build_path(config.marabunta_mig_file_rel_path).as_posix())
+    return new_version, modified
+
+
 @click.group()
 @global_command_decorators
 def cli():
@@ -138,7 +175,7 @@ def cli():
     default=None,
     help="Push the aggregated (pending-merge) branches to upstream.",
 )
-def bump(  # noqa: C901
+def bump(
     rel_type,
     new_version=None,
     do_commit=None,
@@ -155,43 +192,18 @@ def bump(  # noqa: C901
     repo = GitRepo(".")
     # Warn about deprecated .bumpversion.cfg file
     _warn_deprecated_bumpversion_cfg()
-    # Obtain the list files where a version is written
-    files = get_bumpversion_files()
-    if not files:
-        raise click.ClickException(
-            "No files to bump. Configure a VERSION file or create a bundle addon."
-        )
     # Fail early on a dirty tree when we (likely) intend to commit
     if do_commit is not False and repo.is_dirty(untracked_files=True):
         raise click.ClickException(
             "There are uncommitted changes in the working tree. "
             "Commit or stash them before running `bump`."
         )
-    # Bump the version
-    current_version = get_current_version()
-    cmd = make_bumpversion_cmd(
-        rel_type,
-        current_version,
-        files,
-        new_version=new_version,
-    )
-    run(cmd, check=True, verbose=True)
-    # Stage the version files
-    repo.index.add(files)
-    # Obtain the new version after the bump
-    new_version = get_current_version()
-    # Run towncrier to transform changelog into release notes
-    cmd = make_towncrier_cmd(new_version)
-    run(cmd, check=True, verbose=True)
-    # Stage the changelog changes towncrier produced (HISTORY.rst + consumed fragments)
-    history_path = build_path("HISTORY.rst")
-    repo.index.add([history_path.as_posix(), build_path("changes.d").as_posix()])
+    # Run the file-modifying release steps (version, changelog, marabunta)
+    new_version, modified_files = _do_bump(rel_type, new_version=new_version)
+    # Stage everything the release process touched
+    repo.index.add(modified_files)
     # Obtain the release notes from the HISTORY.rst diff
-    release_notes = get_new_release_notes(repo, history_path)
-    # Update the marabunta migration file with the new version
-    if config.marabunta_mig_file_rel_path:
-        update_marabunta_file(new_version)
-        repo.index.add([build_path(config.marabunta_mig_file_rel_path).as_posix()])
+    release_notes = get_new_release_notes(repo, build_path("HISTORY.rst"))
     # Push the aggregated (pending-merge) branches to upstream
     if push_aggregated_branches is None:
         push_aggregated_branches = Confirm.ask(

--- a/odoo_tools/cli/release.py
+++ b/odoo_tools/cli/release.py
@@ -98,6 +98,17 @@ def update_marabunta_file(version):
     handler.update(version)
 
 
+def _warn_deprecated_bumpversion_cfg():
+    """Warn if the deprecated .bumpversion.cfg file is present."""
+    if build_path(".bumpversion.cfg").is_file():
+        console.print(
+            "Deprecated .bumpversion.cfg file found. It is not recommended to use it.\n"
+            "Custom configuration is allowed, but it's recommended to do it in the "
+            "pyproject.toml. See bump-my-version documentation for more details.",
+            style="yellow",
+        )
+
+
 @click.group()
 @global_command_decorators
 def cli():
@@ -143,14 +154,7 @@ def bump(  # noqa: C901
         )
     repo = GitRepo(".")
     # Warn about deprecated .bumpversion.cfg file
-    bumpversion_cfg = build_path(".bumpversion.cfg")
-    if bumpversion_cfg.is_file():
-        console.print(
-            "Deprecated .bumpversion.cfg file found. It is not recommended to use it.\n"
-            "Custom configuration is allowed, but it's recommended to do it in the "
-            "pyproject.toml. See bump-my-version documentation for more details.",
-            style="yellow",
-        )
+    _warn_deprecated_bumpversion_cfg()
     # Obtain the list files where a version is written
     files = get_bumpversion_files()
     if not files:

--- a/odoo_tools/cli/release.py
+++ b/odoo_tools/cli/release.py
@@ -4,11 +4,12 @@
 import click
 from git import Repo as GitRepo
 from rich.console import Console
+from rich.prompt import Confirm
 
 from ..exceptions import ProjectConfigException
 from ..utils.click import global_command_decorators
 from ..utils.config import config
-from ..utils.git import get_current_branch
+from ..utils.git import get_current_branch, tag_signing_enabled
 from ..utils.marabunta import MarabuntaFileHandler
 from ..utils.os_exec import run
 from ..utils.path import build_path
@@ -18,15 +19,24 @@ from ..utils.proj import get_current_version, get_project_bundle_addon_name
 console = Console()
 
 
-END_TIPS = [
-    "Please continue with the release by:",
-    " * Checking the diff",
-    " * Running:",
-    '\tgit commit -m "Release {version}"',
-    "\tgit tag -a {version}  # optionally -s to sign the tag",
-    "\t# copy-paste the content of the release from HISTORY.rst in the annotation of the tag",
-    "\tgit push --tags && git push origin {branch}",
-]
+def get_new_release_notes(repo, history_path):
+    """Return the release notes towncrier just added to HISTORY.rst.
+
+    Reads the diff of HISTORY.rst against HEAD (towncrier only inserts lines)
+    and drops the title (the ``<version> (<date>)`` line and its underline).
+    """
+    diff = repo.git.diff("HEAD", "--", history_path.as_posix())
+    added = []
+    in_hunk = False
+    for line in diff.splitlines():
+        if line.startswith("@@"):
+            in_hunk = True
+        elif in_hunk and line.startswith("+"):
+            added.append(line[1:])
+    # Drop blank seam lines, then the title line and its underline
+    while added and not added[0].strip():
+        added.pop(0)
+    return "\n".join(added[2:]).strip()
 
 
 def get_bumpversion_files():
@@ -99,8 +109,38 @@ def cli():
     "rel_type", type=click.Choice(["major", "minor", "patch"], case_sensitive=False)
 )
 @click.option("--new-version", "new_version", help="explicit new version to create")
-def bump(rel_type, new_version=None):
+@click.option(
+    "--commit/--no-commit",
+    "do_commit",
+    default=None,
+    help="Create the release commit",
+)
+@click.option(
+    "--tag/--no-tag",
+    "do_tag",
+    default=None,
+    help="Create the <VERSION> tag. Implies commit.",
+)
+@click.option(
+    "--push-aggregated-branches/--no-push-aggregated-branches",
+    "push_aggregated_branches",
+    default=None,
+    help="Push the aggregated (pending-merge) branches to upstream.",
+)
+def bump(  # noqa: C901
+    rel_type,
+    new_version=None,
+    do_commit=None,
+    do_tag=None,
+    push_aggregated_branches=None,
+):
     """Prepare a new release"""
+    # --tag requires --commit (only the explicit conflict is an error here;
+    # the undecided None cases are resolved by prompting later)
+    if do_tag is True and do_commit is False:
+        raise click.UsageError(
+            "--tag requires --commit; --tag --no-commit is not allowed."
+        )
     repo = GitRepo(".")
     # Warn about deprecated .bumpversion.cfg file
     bumpversion_cfg = build_path(".bumpversion.cfg")
@@ -117,6 +157,12 @@ def bump(rel_type, new_version=None):
         raise click.ClickException(
             "No files to bump. Configure a VERSION file or create a bundle addon."
         )
+    # Fail early on a dirty tree when we (likely) intend to commit
+    if do_commit is not False and repo.is_dirty(untracked_files=True):
+        raise click.ClickException(
+            "There are uncommitted changes in the working tree. "
+            "Commit or stash them before running `bump`."
+        )
     # Bump the version
     current_version = get_current_version()
     cmd = make_bumpversion_cmd(
@@ -126,25 +172,74 @@ def bump(rel_type, new_version=None):
         new_version=new_version,
     )
     run(cmd, check=True, verbose=True)
+    # Stage the version files
     repo.index.add(files)
     # Obtain the new version after the bump
     new_version = get_current_version()
     # Run towncrier to transform changelog into release notes
     cmd = make_towncrier_cmd(new_version)
     run(cmd, check=True, verbose=True)
+    # Stage the changelog changes towncrier produced (HISTORY.rst + consumed fragments)
+    history_path = build_path("HISTORY.rst")
+    repo.index.add([history_path.as_posix(), build_path("changes.d").as_posix()])
+    # Obtain the release notes from the HISTORY.rst diff
+    release_notes = get_new_release_notes(repo, history_path)
     # Update the marabunta migration file with the new version
     if config.marabunta_mig_file_rel_path:
-        click.echo("Updating marabunta migration file")
         update_marabunta_file(new_version)
-        repo.index.add([build_path(config.marabunta_mig_file_rel_path)])
-    # Push local branches to upstream
-    if click.confirm("Push local branches?"):
+        repo.index.add([build_path(config.marabunta_mig_file_rel_path).as_posix()])
+    # Push the aggregated (pending-merge) branches to upstream
+    if push_aggregated_branches is None:
+        push_aggregated_branches = Confirm.ask(
+            "Push aggregated branches?", default=True
+        )
+    if push_aggregated_branches:
         push_branches(version=new_version, force=True)
-    # Print the manual actions to perform
-    branch = get_current_branch()
-    if branch and new_version:
-        end_tips = "\n".join(END_TIPS).format(branch=branch, version=new_version)
-        click.echo(end_tips)
+    # Resolve the commit decision now that the release files are ready to review
+    if do_commit is None:
+        do_commit = Confirm.ask("Create the release commit?", default=True)
+    if do_commit:
+        # Everything modified by the release process must be staged at this point
+        if repo.is_dirty(index=False, untracked_files=True):
+            raise click.ClickException(
+                "Unexpected changes left in the working tree after staging the "
+                "release files; aborting."
+            )
+        repo.index.commit(f"Release {new_version}")
+        click.echo(f'✅ Committed "Release {new_version}"')
+        # Resolve the tag decision
+        if do_tag is None:
+            do_tag = Confirm.ask("Create the release tag?", default=True)
+        if do_tag:
+            # If the tag already exists, ask before replacing it
+            recreate = True
+            if new_version in [tag.name for tag in repo.tags]:
+                recreate = Confirm.ask(
+                    f'Tag "{new_version}" already exists. Re-create it?',
+                    default=True,
+                )
+            if recreate:
+                repo.create_tag(
+                    new_version,
+                    message=release_notes,
+                    sign=tag_signing_enabled(repo),
+                    force=True,
+                )
+                click.echo(f'✅ Created tag "{new_version}"')
+    # Print manual instructions for pending steps
+    steps = []
+    if not do_commit:
+        steps.append(f'git commit -m "Release {new_version}"')
+    if not do_tag:
+        steps.append(
+            f"git tag -a {new_version}  "
+            "# add -s to sign; use the HISTORY.rst notes as the message"
+        )
+    # bump never pushes the commit/tag itself
+    steps.append(f"git push --tags && git push origin {get_current_branch() or ''}")
+    click.echo("Please continue the release by running:")
+    for step in steps:
+        click.echo(f"\t{step}")
 
 
 if __name__ == "__main__":

--- a/odoo_tools/cli/release.py
+++ b/odoo_tools/cli/release.py
@@ -1,19 +1,26 @@
 # Copyright 2023 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
 import click
 from git import Repo as GitRepo
 from rich.console import Console
+from rich.live import Live
+from rich.markup import escape
 from rich.prompt import Confirm
+from rich.spinner import Spinner
+from rich.table import Table
 
 from ..exceptions import ProjectConfigException
+from ..utils import gh, ui
 from ..utils.click import global_command_decorators
 from ..utils.config import config
 from ..utils.git import get_current_branch, tag_signing_enabled
 from ..utils.marabunta import MarabuntaFileHandler
 from ..utils.os_exec import run
 from ..utils.path import build_path
-from ..utils.pending_merge import push_branches
+from ..utils.pending_merge import Repo, make_merge_branch_name
 from ..utils.proj import get_current_version, get_project_bundle_addon_name
 
 console = Console()
@@ -146,6 +153,77 @@ def _do_bump(rel_type, new_version=None):
     return new_version, modified
 
 
+def _push_repo_branch(repo, branch_name, company_git_remote):
+    """Push a single repo's pending-merge branch to the company remote."""
+    merges_config = repo.merges_config()
+    try:
+        run(f"git config remote.{company_git_remote}.url", cwd=repo.abs_path)
+    except Exception:  # TODO
+        remote_url = merges_config["remotes"][company_git_remote]
+        run(f"git remote add {company_git_remote} {remote_url}", cwd=repo.abs_path)
+    run(
+        f"git push -f -v {company_git_remote} HEAD:refs/heads/{branch_name}",
+        cwd=repo.abs_path,
+    )
+
+
+def _push_aggregated_branches(version=None, force=False):
+    """Push the local aggregated (pending-merge) branches to the company remote.
+
+    The branch name is composed of the project id and the version number. It is
+    done when closing a release, so a new patch branch can be rebuilt from the
+    same commits if required. Repos are pushed in parallel.
+    """
+    version = version or get_current_version()
+    branch_name = make_merge_branch_name(version)
+    if not force and gh.check_git_diff():
+        ui.ask_or_abort(
+            "Your repository has local changes, are you sure you want to continue?"
+        )
+    company_git_remote = config.company_git_remote
+    repos = [
+        repo
+        for repo in Repo.repositories_from_pending_folder()
+        if repo.has_pending_merges()
+    ]
+    if not repos:
+        ui.echo("No repo to push")
+        return
+    states = {}  # repo -> "done" | error message
+
+    def build_grid():
+        grid = Table.grid(padding=(0, 1))
+        grid.add_column(no_wrap=True)  # state dot / spinner
+        grid.add_column(no_wrap=True, overflow="ellipsis")  # repo + outcome
+        for repo in repos:
+            state = states.get(repo)
+            path = repo.path.as_posix()
+            if state is None:
+                grid.add_row(Spinner("dots"), path)
+            elif state == "done":
+                grid.add_row("[green]●[/]", f"{path} [green]pushed {branch_name}[/]")
+            else:
+                grid.add_row("[red]?[/]", f"{path} [red]{escape(state)}[/]")
+        return grid
+
+    with (
+        Live(build_grid(), console=console, refresh_per_second=10) as live,
+        ThreadPoolExecutor(max_workers=8) as pool,
+    ):
+        futures = {
+            pool.submit(_push_repo_branch, repo, branch_name, company_git_remote): repo
+            for repo in repos
+        }
+        for future in as_completed(futures):
+            repo = futures[future]
+            try:
+                future.result()
+                states[repo] = "done"
+            except Exception as exc:
+                states[repo] = str(exc)
+            live.update(build_grid())
+
+
 @click.group()
 @global_command_decorators
 def cli():
@@ -210,7 +288,7 @@ def bump(
             "Push aggregated branches?", default=True
         )
     if push_aggregated_branches:
-        push_branches(version=new_version, force=True)
+        _push_aggregated_branches(version=new_version, force=True)
     # Resolve the commit decision now that the release files are ready to review
     if do_commit is None:
         do_commit = Confirm.ask("Create the release commit?", default=True)

--- a/odoo_tools/utils/git.py
+++ b/odoo_tools/utils/git.py
@@ -329,6 +329,24 @@ def get_current_branch():
     return branch
 
 
+def tag_signing_enabled(repo):
+    """Return True if git is configured to sign tags.
+
+    ``tag.gpgsign`` is authoritative when set (so an explicit ``false`` disables
+    signing even if a signing key exists); otherwise we fall back to the
+    presence of a ``user.signingkey``.
+    """
+    with repo.config_reader() as reader:
+        try:
+            return bool(reader.get_value("tag", "gpgsign"))
+        except Exception:
+            pass
+        try:
+            return bool(reader.get_value("user", "signingkey"))
+        except Exception:
+            return False
+
+
 def delete_branch(branch_name):
     run(["git", "branch", "-D", branch_name])
 

--- a/odoo_tools/utils/os_exec.py
+++ b/odoo_tools/utils/os_exec.py
@@ -32,13 +32,16 @@ def get_venv():
     return env
 
 
-def run(cmd, drop_trailing_spaces=True, check=False, with_env=None, verbose=False):
+def run(
+    cmd, drop_trailing_spaces=True, check=False, with_env=None, verbose=False, cwd=None
+):
     """Execute system commands and return output.
 
     :param cmd: the command to execute, as a string or a preparsed list
     :param drop_trailing_eol: remove trailing end-of-line chars or other wrapping spaces.
     :param with_env: a dictionary of environment variables to set, or None.
     :param verbose: if True, print the command before running it.
+    :param cwd: the working directory to run the command in, or None.
     """
     if isinstance(cmd, str):
         cmd = shlex.split(cmd)
@@ -48,7 +51,7 @@ def run(cmd, drop_trailing_spaces=True, check=False, with_env=None, verbose=Fals
     if with_env:
         env.update(with_env)
     try:
-        res = subprocess.run(cmd, capture_output=True, env=env, check=check)
+        res = subprocess.run(cmd, capture_output=True, env=env, check=check, cwd=cwd)
     except subprocess.CalledProcessError as e:
         if e.stderr:
             print(e.stderr.decode(), file=sys.stderr)

--- a/odoo_tools/utils/pending_merge.py
+++ b/odoo_tools/utils/pending_merge.py
@@ -19,9 +19,8 @@ from ..exceptions import PathNotFound
 from ..utils.misc import SmartDict, get_docker_image_commit_hashes
 from . import gh, git, ui
 from .config import config
-from .os_exec import run
 from .path import build_path, cd
-from .proj import get_current_version, get_project_manifest_key
+from .proj import get_project_manifest_key
 from .yaml import (
     append_seq_item_with_comments,
     remove_seq_item_with_comments,
@@ -724,46 +723,6 @@ def make_merge_branch_name(version):
     project_id = get_project_manifest_key("project_id")
     branch_name = f"merge-branch-{project_id}-{version}"
     return branch_name
-
-
-def push_branches(version=None, force=False):
-    """Push the local branches to the camptocamp remote
-
-    The branch name will be composed of the id of the project and the current
-    version number (the one in odoo/VERSION).
-
-    It should be done at the closing of every release, so we are able
-    to build a new patch branch from the same commits if required.
-    """
-    version = version or get_current_version()
-    branch_name = make_merge_branch_name(version)
-    if not force:
-        if gh.check_git_diff():
-            ui.ask_or_abort(
-                "Your repository has local changes, are you sure you want to continue?"
-            )
-
-    # look through all of the files inside PENDING_MERGES_DIR, push everything
-    impacted_repos = []
-    company_git_remote = config.company_git_remote
-    for repo in Repo.repositories_from_pending_folder():
-        if not repo.has_pending_merges():
-            continue
-        merges_config = repo.merges_config()
-        impacted_repos.append(repo.path)
-        ui.echo(f"Pushing {repo.path}")
-        with cd(repo.abs_path):
-            try:
-                run(f"git config remote.{company_git_remote}.url")
-            except Exception:  # TODO
-                remote_url = merges_config["remotes"][company_git_remote]
-                run(f"git remote add {company_git_remote} {remote_url}")
-            run(f"git push -f -v {company_git_remote} HEAD:refs/heads/{branch_name}")
-    if impacted_repos:
-        ui.echo("Impacted repos:")
-        ui.echo("\n - ".join([x.as_posix() for x in impacted_repos]))
-    else:
-        ui.echo("No repo to push")
 
 
 def get_new_remote_url(repo: Repo, force_remote: str | bool = False):

--- a/tests/common.py
+++ b/tests/common.py
@@ -128,6 +128,10 @@ def make_fake_project_root(
         with repo.config_writer() as cfg:
             cfg.set_value("user", "email", "test@test.com")
             cfg.set_value("user", "name", "Test")
+            # Disable signing so tests never invoke GPG, regardless of the
+            # developer's global git configuration.
+            cfg.set_value("tag", "gpgsign", "false")
+            cfg.set_value("commit", "gpgsign", "false")
         repo.index.add(repo.untracked_files)
         repo.index.commit("initial commit")
 

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -11,15 +11,16 @@ import pytest
 from odoo_tools.cli import release
 from odoo_tools.cli.project import init
 from odoo_tools.utils.config import config
+from odoo_tools.utils.git import tag_signing_enabled
 
 from .common import compare_line_by_line, mock_pending_merge_repo_paths
 
 
 def git_commit_all(message="commit"):
-    """Helper to commit all changes in the current directory."""
+    """Commit everything in the working tree, to get a clean starting point."""
     repo = git.Repo(".")
     repo.git.add("-A")
-    repo.index.commit(message)
+    repo.git.commit("--message", message)
 
 
 def test_make_towncrier_cmd():
@@ -35,29 +36,32 @@ def test_bump(project):
     assert ver_file.read_text() == "14.0.0.1.0"
     # run init to get all files ready (eg: towncrier)
     project.invoke(init, catch_exceptions=False)
-    project.invoke(release.bump, ["patch"], catch_exceptions=False)
+    # the commit flow requires a clean tree to start from
+    git_commit_all()
+
+    def bump(*args):
+        # --commit --tag exercises the full release path without prompting;
+        # the bump auto-commits, so no manual git_commit_all is needed between calls.
+        project.invoke(
+            release.bump,
+            [*args, "--commit", "--tag"],
+            catch_exceptions=False,
+            input="n",
+        )
+
+    bump("patch")
     assert ver_file.read_text() == "14.0.0.1.1"
-    git_commit_all()
-    project.invoke(release.bump, ["minor"], catch_exceptions=False)
+    bump("minor")
     assert ver_file.read_text() == "14.0.0.2.0"
-    git_commit_all()
-    project.invoke(release.bump, ["major"], catch_exceptions=False)
+    bump("major")
     assert ver_file.read_text() == "14.0.1.0.0"
-    git_commit_all()
-    project.invoke(release.bump, ["minor"], catch_exceptions=False)
+    bump("minor")
     assert ver_file.read_text() == "14.0.1.1.0"
-    git_commit_all()
-    project.invoke(release.bump, ["patch"], catch_exceptions=False)
+    bump("patch")
     assert ver_file.read_text() == "14.0.1.1.1"
-    git_commit_all()
-    project.invoke(release.bump, ["major"], catch_exceptions=False)
+    bump("major")
     assert ver_file.read_text() == "14.0.2.0.0"
-    git_commit_all()
-    project.invoke(
-        release.bump,
-        ["major", "--new-version", "15.0.0.0.1"],
-        catch_exceptions=False,
-    )
+    bump("major", "--new-version", "15.0.0.0.1")
     assert ver_file.read_text() == "15.0.0.0.1"
 
 
@@ -97,7 +101,12 @@ def test_bump_changelog(project):
     (cwd / "changes.d/1234.bug").write_text("Fixed a thing!")
     (cwd / "changes.d/2345.feat").write_text("Added a thing!")
     (cwd / "HISTORY.rst").write_text(hist_part_1 + hist_part_2)
-    result = project.invoke(release.bump, ["minor"], catch_exceptions=False, input="n")
+    result = project.invoke(
+        release.bump,
+        ["minor", "--no-commit", "--no-tag"],
+        catch_exceptions=False,
+        input="n",
+    )
     new_part = (
         f"14.0.0.2.0 ({datetime.date.today():%Y-%m-%d})\n"
         "+++++++++++++++++++++++\n\n"
@@ -112,13 +121,8 @@ def test_bump_changelog(project):
         (cwd / "HISTORY.rst").read_text(),
         hist_part_1 + new_part + hist_part_2,
     )
-    output_lines = result.output.splitlines()
-    assert output_lines[0].startswith("Running: bump-my-version bump")
-    assert output_lines[1:4] == [
-        "Running: towncrier build --yes --version=14.0.0.2.0",
-        "Updating marabunta migration file",
-        "Push local branches? [y/N]: n",
-    ]
+    assert result.output.splitlines()[0].startswith("Running: bump-my-version bump")
+    assert "Running: towncrier build --yes --version=14.0.0.2.0" in result.output
     assert result.exit_code == 0
 
 
@@ -128,16 +132,16 @@ def test_bump_changelog(project):
 def test_bump_update_marabunta_file(project):
     # run init to get all files ready (eg: towncrier)
     project.invoke(init, catch_exceptions=False)
-    result = project.invoke(release.bump, ["minor"], catch_exceptions=False, input="\n")
+    result = project.invoke(
+        release.bump,
+        ["minor", "--no-commit", "--no-tag"],
+        catch_exceptions=False,
+        input="n",
+    )
     content = config.marabunta_mig_file_rel_path.read_text()
     assert "14.0.0.2.0" in content
-    output_lines = result.output.splitlines()
-    assert output_lines[0].startswith("Running: bump-my-version bump")
-    assert output_lines[1:4] == [
-        "Running: towncrier build --yes --version=14.0.0.2.0",
-        "Updating marabunta migration file",
-        "Push local branches? [y/N]: ",
-    ]
+    assert result.output.splitlines()[0].startswith("Running: bump-my-version bump")
+    assert "Running: towncrier build --yes --version=14.0.0.2.0" in result.output
     assert result.exit_code == 0
 
 
@@ -150,13 +154,14 @@ def test_bump_update_marabunta_file(project):
 def test_bump_update_without_marabunta_file(project):
     # run init to get all files ready (eg: towncrier)
     project.invoke(init, catch_exceptions=False)
-    result = project.invoke(release.bump, ["minor"], catch_exceptions=False, input="\n")
-    output_lines = result.output.splitlines()
-    assert output_lines[0].startswith("Running: bump-my-version bump")
-    assert output_lines[1:3] == [
-        "Running: towncrier build --yes --version=14.0.0.2.0",
-        "Push local branches? [y/N]: ",
-    ]
+    result = project.invoke(
+        release.bump,
+        ["minor", "--no-commit", "--no-tag"],
+        catch_exceptions=False,
+        input="n",
+    )
+    assert result.output.splitlines()[0].startswith("Running: bump-my-version bump")
+    assert "Running: towncrier build --yes --version=14.0.0.2.0" in result.output
     assert result.exit_code == 0
 
 
@@ -191,14 +196,14 @@ def test_bump_bundle_addon_manifest_version(project):
     # run init to get all files ready (eg: towncrier)
     project.invoke(init, catch_exceptions=False)
     # bump the version
-    result = project.invoke(release.bump, ["minor"], catch_exceptions=False, input="\n")
-    output_lines = result.output.splitlines()
-    assert output_lines[0].startswith("Running: bump-my-version bump")
-    assert output_lines[1:4] == [
-        "Running: towncrier build --yes --version=18.0.1.3.0",
-        "Updating marabunta migration file",
-        "Push local branches? [y/N]: ",
-    ]
+    result = project.invoke(
+        release.bump,
+        ["minor", "--no-commit", "--no-tag"],
+        catch_exceptions=False,
+        input="n",
+    )
+    assert result.output.splitlines()[0].startswith("Running: bump-my-version bump")
+    assert "Running: towncrier build --yes --version=18.0.1.3.0" in result.output
     assert result.exit_code == 0
     # make sure the bundle addon version is updated in both files
     assert "18.0.1.3.0" in (bundle_addon_path / "__manifest__.py").read_text()
@@ -220,14 +225,14 @@ def test_bump_bundle_addon_manifest_version_without_version_file(project):
     # run init to get all files ready (eg: towncrier)
     project.invoke(init, catch_exceptions=False)
     # bump the version
-    result = project.invoke(release.bump, ["minor"], catch_exceptions=False, input="\n")
-    output_lines = result.output.splitlines()
-    assert output_lines[0].startswith("Running: bump-my-version bump")
-    assert output_lines[1:4] == [
-        "Running: towncrier build --yes --version=18.0.1.3.0",
-        "Updating marabunta migration file",
-        "Push local branches? [y/N]: ",
-    ]
+    result = project.invoke(
+        release.bump,
+        ["minor", "--no-commit", "--no-tag"],
+        catch_exceptions=False,
+        input="n",
+    )
+    assert result.output.splitlines()[0].startswith("Running: bump-my-version bump")
+    assert "Running: towncrier build --yes --version=18.0.1.3.0" in result.output
     assert result.exit_code == 0
     # make sure the bundle addon version is updated in both files
     assert "18.0.1.3.0" in (bundle_addon_path / "__manifest__.py").read_text()
@@ -239,14 +244,14 @@ def test_bump_bundle_addon_manifest_version_without_version_file(project):
 def test_bump_push_no_repo(project):
     # run init to get all files ready (eg: towncrier)
     project.invoke(init, catch_exceptions=False)
-    result = project.invoke(release.bump, ["minor"], catch_exceptions=False, input="y")
-    output_lines = result.output.splitlines()
-    assert output_lines[0].startswith("Running: bump-my-version bump")
-    assert output_lines[1:4] == [
-        "Running: towncrier build --yes --version=14.0.0.2.0",
-        "Updating marabunta migration file",
-        "Push local branches? [y/N]: y",
-    ]
+    result = project.invoke(
+        release.bump,
+        ["minor", "--no-commit", "--no-tag"],
+        catch_exceptions=False,
+        input="y",
+    )
+    assert result.output.splitlines()[0].startswith("Running: bump-my-version bump")
+    assert "Running: towncrier build --yes --version=14.0.0.2.0" in result.output
     assert "No repo to push" in result.output
     assert result.exit_code == 0
 
@@ -266,19 +271,266 @@ def test_bump_push_repo_with_pending_merge(project):
     project.invoke(init, catch_exceptions=False)
     with mock.patch("odoo_tools.utils.pending_merge.run", mocked_run):
         result = project.invoke(
-            release.bump, ["minor"], catch_exceptions=False, input="y"
+            release.bump,
+            ["minor", "--no-commit", "--no-tag"],
+            catch_exceptions=False,
+            input="y",
         )
-    output_lines = result.output.splitlines()
-    assert output_lines[0].startswith("Running: bump-my-version bump")
-    assert output_lines[1:6] == [
-        "Running: towncrier build --yes --version=14.0.0.2.0",
-        "Updating marabunta migration file",
-        "Push local branches? [y/N]: y",
-        "Pushing odoo/external-src/edi-framework",
-        "Impacted repos:",
-    ]
+    assert result.output.splitlines()[0].startswith("Running: bump-my-version bump")
+    assert "Running: towncrier build --yes --version=14.0.0.2.0" in result.output
+    assert "Pushing odoo/external-src/edi-framework" in result.output
     assert ran_cmd == [
         "git config remote.camptocamp.url",
         "git push -f -v camptocamp HEAD:refs/heads/merge-branch-1234-14.0.0.2.0",
     ]
     assert result.exit_code == 0
+
+
+def test_get_new_release_notes(tmp_path):
+    repo = git.Repo.init(tmp_path)
+    with repo.config_writer() as cfg:
+        cfg.set_value("user", "email", "test@test.com")
+        cfg.set_value("user", "name", "Test")
+    head = (
+        ".. :changelog:\n"
+        ".. DO NOT EDIT. File is generated from fragments.\n\n"
+        "Release History\n"
+        "---------------\n\n"
+        ".. towncrier release notes start\n\n"
+    )
+    old = "14.0.0.1.0 (2011-10-09)\n+++++++++++++++++++++++\n\n* Blah\n"
+    history = tmp_path / "HISTORY.rst"
+    history.write_text(head + old)
+    repo.git.add("-A")
+    repo.git.commit("--message", "init")
+    # towncrier inserts the new release block right after the marker
+    new_block = (
+        "14.0.0.2.0 (2026-06-29)\n"
+        "+++++++++++++++++++++++\n\n"
+        "**Features and Improvements**\n\n"
+        "* 2345: Added a thing!\n\n"
+        "**Bugfixes**\n\n"
+        "* 1234: Fixed a thing!\n\n\n"
+    )
+    history.write_text(head + new_block + old)
+    expected = (
+        "**Features and Improvements**\n\n"
+        "* 2345: Added a thing!\n\n"
+        "**Bugfixes**\n\n"
+        "* 1234: Fixed a thing!"
+    )
+    assert release.get_new_release_notes(repo, history) == expected
+
+
+def test_tag_signing_enabled(tmp_path):
+    repo = git.Repo.init(tmp_path)
+    # tag.gpgsign is authoritative when set
+    with repo.config_writer() as cfg:
+        cfg.set_value("tag", "gpgsign", "true")
+    assert tag_signing_enabled(repo) is True
+    with repo.config_writer() as cfg:
+        cfg.set_value("tag", "gpgsign", "false")
+    assert tag_signing_enabled(repo) is False
+
+
+@pytest.mark.project_setup(
+    proj_version="14.0.0.1.0", mock_marabunta_file=True, git_init=True
+)
+def test_bump_commit_and_tag(project):
+    project.invoke(init, catch_exceptions=False)
+    cwd = Path()
+    (cwd / "changes.d/1234.bug").write_text("Fixed a thing!")
+    (cwd / "changes.d/2345.feat").write_text("Added a thing!")
+    # the commit flow requires a clean tree to start from
+    git_commit_all()
+    result = project.invoke(
+        release.bump,
+        ["minor", "--commit", "--tag"],
+        catch_exceptions=False,
+        input="n",
+    )
+    assert result.exit_code == 0
+    assert '✅ Committed "Release 14.0.0.2.0"' in result.output
+    assert '✅ Created tag "14.0.0.2.0"' in result.output
+    repo = git.Repo(".")
+    # A "Release X" commit was created, and it includes the release files
+    assert repo.head.commit.message.strip() == "Release 14.0.0.2.0"
+    committed_files = repo.head.commit.stats.files
+    assert "HISTORY.rst" in committed_files
+    # The annotated tag exists and its message is the release notes without the title
+    tag_object = repo.tags["14.0.0.2.0"].tag
+    assert tag_object is not None
+    message = tag_object.message
+    assert "14.0.0.2.0 (" not in message
+    assert "+++" not in message
+    assert "**Features and Improvements**" in message
+    assert "* 2345: Added a thing!" in message
+    assert "**Bugfixes**" in message
+    assert "* 1234: Fixed a thing!" in message
+    # No manual commit/tag tips, since the tool did both
+    assert "git commit -m" not in result.output
+    assert "git tag -a" not in result.output
+    # The working tree is clean afterwards
+    assert not repo.is_dirty(untracked_files=True, submodules=False)
+
+
+@pytest.mark.project_setup(
+    proj_version="14.0.0.1.0", mock_marabunta_file=True, git_init=True
+)
+def test_bump_commit_no_tag(project):
+    project.invoke(init, catch_exceptions=False)
+    # the commit flow requires a clean tree to start from
+    git_commit_all()
+    result = project.invoke(
+        release.bump,
+        ["minor", "--commit", "--no-tag"],
+        catch_exceptions=False,
+        input="n",
+    )
+    assert result.exit_code == 0
+    repo = git.Repo(".")
+    # The commit was created but no tag
+    assert repo.head.commit.message.strip() == "Release 14.0.0.2.0"
+    assert len(repo.tags) == 0
+    # Only the tag tip is shown (commit was done by the tool)
+    assert "git commit -m" not in result.output
+    assert "git tag -a 14.0.0.2.0" in result.output
+
+
+@pytest.mark.project_setup(
+    proj_version="14.0.0.1.0", mock_marabunta_file=True, git_init=True
+)
+def test_bump_tag_recreate(project):
+    project.invoke(init, catch_exceptions=False)
+    git_commit_all()
+    repo = git.Repo(".")
+    # Pre-create the tag the bump will want to create
+    repo.create_tag("14.0.0.2.0", message="old message")
+    # push? no / re-create tag? yes
+    result = project.invoke(
+        release.bump,
+        ["minor", "--commit", "--tag"],
+        catch_exceptions=False,
+        input="n\ny\n",
+    )
+    assert result.exit_code == 0
+    assert 'Tag "14.0.0.2.0" already exists. Re-create it?' in result.output
+    # The tag was replaced: it now points at the release commit, not the old message
+    tag = repo.tags["14.0.0.2.0"]
+    tag_object = tag.tag
+    assert tag_object is not None
+    assert tag_object.message != "old message"
+    assert tag.commit == repo.head.commit
+
+
+@pytest.mark.project_setup(
+    proj_version="14.0.0.1.0", mock_marabunta_file=True, git_init=True
+)
+def test_bump_tag_recreate_declined(project):
+    project.invoke(init, catch_exceptions=False)
+    git_commit_all()
+    repo = git.Repo(".")
+    repo.create_tag("14.0.0.2.0", message="old message")
+    # push? no / re-create tag? no
+    result = project.invoke(
+        release.bump,
+        ["minor", "--commit", "--tag"],
+        catch_exceptions=False,
+        input="n\nn\n",
+    )
+    assert result.exit_code == 0
+    # The commit was still created, but the existing tag is left untouched
+    assert repo.head.commit.message.strip() == "Release 14.0.0.2.0"
+    tag_object = repo.tags["14.0.0.2.0"].tag
+    assert tag_object is not None
+    assert tag_object.message == "old message"
+    assert "✅ Created tag" not in result.output
+
+
+@pytest.mark.project_setup(
+    proj_version="14.0.0.1.0", mock_marabunta_file=True, git_init=True
+)
+def test_bump_prompts_commit_and_tag(project):
+    project.invoke(init, catch_exceptions=False)
+    # the commit flow requires a clean tree to start from
+    git_commit_all()
+    # push? no / commit? yes / tag? yes  (prompts are asked in that order)
+    result = project.invoke(
+        release.bump, ["minor"], catch_exceptions=False, input="n\ny\ny\n"
+    )
+    assert result.exit_code == 0
+    assert "Create the release commit?" in result.output
+    assert "Create the release tag?" in result.output
+    repo = git.Repo(".")
+    assert repo.head.commit.message.strip() == "Release 14.0.0.2.0"
+    assert "14.0.0.2.0" in [tag.name for tag in repo.tags]
+
+
+@pytest.mark.project_setup(
+    proj_version="14.0.0.1.0", mock_marabunta_file=True, git_init=True
+)
+def test_bump_prompts_decline_commit(project):
+    project.invoke(init, catch_exceptions=False)
+    # check(a) runs while the commit decision is undecided, so start clean
+    git_commit_all()
+    head_before = git.Repo(".").head.commit.hexsha
+    # commit? no -> the tag prompt must NOT appear / push? no
+    result = project.invoke(
+        release.bump, ["minor"], catch_exceptions=False, input="n\nn\n"
+    )
+    assert result.exit_code == 0
+    assert "Create the release commit?" in result.output
+    assert "Create the release tag?" not in result.output
+    repo = git.Repo(".")
+    assert repo.head.commit.hexsha == head_before
+    assert len(repo.tags) == 0
+
+
+@pytest.mark.project_setup(
+    proj_version="14.0.0.1.0", mock_marabunta_file=True, git_init=True
+)
+def test_bump_no_commit(project):
+    project.invoke(init, catch_exceptions=False)
+    head_before = git.Repo(".").head.commit.hexsha
+    result = project.invoke(
+        release.bump,
+        ["minor", "--no-commit", "--no-tag"],
+        catch_exceptions=False,
+        input="n",
+    )
+    assert result.exit_code == 0
+    repo = git.Repo(".")
+    assert repo.head.commit.hexsha == head_before
+    assert len(repo.tags) == 0
+    # Manual commit and tag tips are shown since the tool did neither
+    assert 'git commit -m "Release 14.0.0.2.0"' in result.output
+    assert "git tag -a 14.0.0.2.0" in result.output
+
+
+@pytest.mark.project_setup(
+    proj_version="14.0.0.1.0", mock_marabunta_file=True, git_init=True
+)
+def test_bump_tag_requires_commit(project):
+    project.invoke(init, catch_exceptions=False)
+    ver_file = config.version_file_rel_path
+    result = project.invoke(release.bump, ["minor", "--tag", "--no-commit"])
+    assert result.exit_code != 0
+    assert "--tag requires --commit" in result.output
+    # Version untouched (we fail before mutating anything)
+    assert ver_file.read_text() == "14.0.0.1.0"
+
+
+@pytest.mark.project_setup(
+    proj_version="14.0.0.1.0", mock_marabunta_file=True, git_init=True
+)
+def test_bump_fails_on_unstaged_changes(project):
+    project.invoke(init, catch_exceptions=False)
+    git_commit_all()
+    # Modify a tracked file without staging it
+    Path("requirements.txt").write_text("a-dependency\n")
+    ver_file = config.version_file_rel_path
+    result = project.invoke(release.bump, ["minor", "--commit"])
+    assert result.exit_code != 0
+    assert "uncommitted changes" in result.output.lower()
+    # The release did not proceed
+    assert ver_file.read_text() == "14.0.0.1.0"

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -263,28 +263,33 @@ def test_bump_push_no_repo(project):
 )
 def test_bump_push_repo_with_pending_merge(project):
     ran_cmd = []
+    real_run = release.run
 
-    def mocked_run(cmd):
-        ran_cmd.append(cmd)
+    def mocked_run(cmd, **kwargs):
+        # Only the per-repo branch push runs with an explicit cwd; record those
+        # and let the real bump/towncrier commands execute.
+        if "cwd" in kwargs:
+            ran_cmd.append(cmd)
+            return ""
+        return real_run(cmd, **kwargs)
 
     mock_pending_merge_repo_paths("edi-framework")
     # run init to get all files ready (eg: towncrier)
     project.invoke(init, catch_exceptions=False)
-    with mock.patch("odoo_tools.utils.pending_merge.run", mocked_run):
+    with mock.patch("odoo_tools.cli.release.run", mocked_run):
         result = project.invoke(
             release.bump,
             ["minor", "--no-commit", "--no-tag"],
             catch_exceptions=False,
             input="y",
         )
-    assert result.output.splitlines()[0].startswith("Running: bump-my-version bump")
-    assert "Running: towncrier build --yes --version=14.0.0.2.0" in result.output
-    assert "Pushing odoo/external-src/edi-framework" in result.output
+    assert result.exit_code == 0
     assert ran_cmd == [
         "git config remote.camptocamp.url",
         "git push -f -v camptocamp HEAD:refs/heads/merge-branch-1234-14.0.0.2.0",
     ]
-    assert result.exit_code == 0
+    # the pushed repo shows up in the live progress grid
+    assert "edi-framework" in result.output
 
 
 def test_get_new_release_notes(tmp_path):

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -174,6 +174,7 @@ def test_bump_update_without_marabunta_file(project):
 def test_bump_without_version_file_and_no_bundle_addon(project):
     # run init to get all files ready
     project.invoke(init, catch_exceptions=False)
+    git_commit_all()
     # check that the version file is not present
     assert config.version_file_rel_path is None
     # bump should fail because there are no files to bump


### PR DESCRIPTION
`otools-release bump` now offers to create the commit and tag.

Also, do the push of aggregated branches in parallel which speeds up time


Example:

https://github.com/user-attachments/assets/161de0ae-0372-460c-981a-4cdf180891a1

