### PR TITLE
[IMP] os_exec: print verbose 'Running' message in gray

### DIFF
--- a/odoo_tools/utils/os_exec.py
+++ b/odoo_tools/utils/os_exec.py
@@ -43,7 +43,7 @@ def run(cmd, drop_trailing_spaces=True, check=False, with_env=None, verbose=Fals
     if isinstance(cmd, str):
         cmd = shlex.split(cmd)
     if verbose:
-        click.echo(f"Running: {shlex.join(cmd)}")
+        click.echo(click.style(f"Running: {shlex.join(cmd)}", fg="bright_black"))
     env = get_venv()
     if with_env:
         env.update(with_env)


### PR DESCRIPTION
## Description

When calling `os_exec.run(..., verbose=True)`, the printed `Running: ...` message is now styled in gray (`bright_black`) to visually distinguish it from the actual command output.

`click.echo` strips the ANSI color codes automatically when the output stream is not a terminal, so existing tests asserting on the `Running: ...` text continue to pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)