### PR TITLE
[FIX] submodule: only add OCA/company remote when the repo exists (#230)

### DIFF
--- a/odoo_tools/utils/git.py
+++ b/odoo_tools/utils/git.py
@@ -3,6 +3,7 @@
 
 import subprocess
 from collections.abc import Iterator
+from functools import cache
 from os import PathLike
 from pathlib import Path
 from typing import NamedTuple
@@ -22,7 +23,7 @@ def _repo_name_from_url(url: str) -> str:
     return url.rstrip("/").split("/")[-1].removesuffix(".git")
 
 
-def _remote_exists(git_dir: str | Path, remote_name: str) -> bool:
+def remote_exists(git_dir: str | Path, remote_name: str) -> bool:
     """Return True if the named remote exists in the repo at git_dir."""
     result = subprocess.run(
         ["git", "-C", str(git_dir), "remote", "get-url", remote_name],
@@ -31,12 +32,29 @@ def _remote_exists(git_dir: str | Path, remote_name: str) -> bool:
     return result.returncode == 0
 
 
+@cache
+def remote_repo_exists(url: str) -> bool:
+    """Return True if the github repository at ``url`` is reachable.
+
+    Used to avoid registering a remote that points to a non-existent repository.
+    A dangling remote breaks git's fallback ``fetch --all`` with
+    ``Repository not found``, which is exactly what registering targeted remotes
+    is meant to prevent.
+
+    Results are cached because ``setup_submodule_remotes`` is called twice per
+    submodule (autoshare cache and working tree), so the network probe would
+    otherwise be repeated.
+    """
+    result = subprocess.run(["git", "ls-remote", url], capture_output=True)
+    return result.returncode == 0
+
+
 def ensure_remote(git_dir: str | Path, remote_name: str, url: str) -> bool:
     """Add a named remote if it doesn't already exist.
 
     Returns True if the remote was added, False if it was already present.
     """
-    if _remote_exists(git_dir, remote_name):
+    if remote_exists(git_dir, remote_name):
         return False
     run(
         ["git", "-C", str(git_dir), "remote", "add", remote_name, url],
@@ -72,20 +90,31 @@ def setup_submodule_remotes(
       OCA              -> base branch only (e.g. refs/heads/18.0)
       <company_remote> -> merge-branch-<project_id>-* only (skipped when project_id is None)
 
+    A remote is only added when the corresponding github repository actually
+    exists. Many submodules are not OCA repositories (e.g. private
+    ``<company_remote>/...`` modules), so blindly adding an ``OCA/<repo>`` remote
+    would point at a non-existent repository and break git's fallback fetch.
+
+    The (network) existence probe is skipped when the remote is already
+    configured locally: an existing remote is trusted and only re-fetched.
+
     Safe to call on both submodule working trees and autoshare bare caches.
     """
     repo_name = _repo_name_from_url(submodule_url)
     oca_url = f"git@github.com:OCA/{repo_name}.git"
     c2c_url = f"git@github.com:{company_remote}/{repo_name}.git"
 
-    ensure_remote(repo_path, "OCA", oca_url)
-    fetch_targeted(
-        repo_path,
-        "OCA",
-        f"+refs/heads/{base_branch}:refs/remotes/OCA/{base_branch}",
-    )
+    if remote_exists(repo_path, "OCA") or remote_repo_exists(oca_url):
+        ensure_remote(repo_path, "OCA", oca_url)
+        fetch_targeted(
+            repo_path,
+            "OCA",
+            f"+refs/heads/{base_branch}:refs/remotes/OCA/{base_branch}",
+        )
 
-    if project_id:
+    if project_id and (
+        remote_exists(repo_path, company_remote) or remote_repo_exists(c2c_url)
+    ):
         ensure_remote(repo_path, company_remote, c2c_url)
         fetch_targeted(
             repo_path,

--- a/tests/test_utils_git.py
+++ b/tests/test_utils_git.py
@@ -63,13 +63,13 @@ def test_repo_name_from_url_trailing_slash():
     assert git_utils._repo_name_from_url("git@github.com:OCA/foo.git/") == "foo"
 
 
-# ── _remote_exists ────────────────────────────────────────────────────────────
+# ── remote_exists ────────────────────────────────────────────────────────────
 
 
 def test_remote_exists_true():
     with mock.patch("subprocess.run") as mock_run:
         mock_run.return_value = mock.Mock(returncode=0)
-        assert git_utils._remote_exists("/some/path", "OCA") is True
+        assert git_utils.remote_exists("/some/path", "OCA") is True
         mock_run.assert_called_once_with(
             ["git", "-C", "/some/path", "remote", "get-url", "OCA"],
             capture_output=True,
@@ -79,7 +79,7 @@ def test_remote_exists_true():
 def test_remote_exists_false():
     with mock.patch("subprocess.run") as mock_run:
         mock_run.return_value = mock.Mock(returncode=128)
-        assert git_utils._remote_exists("/some/path", "OCA") is False
+        assert git_utils.remote_exists("/some/path", "OCA") is False
 
 
 # ── ensure_remote ─────────────────────────────────────────────────────────────
@@ -87,7 +87,7 @@ def test_remote_exists_false():
 
 def test_ensure_remote_adds_when_missing():
     with (
-        mock.patch("odoo_tools.utils.git._remote_exists", return_value=False),
+        mock.patch("odoo_tools.utils.git.remote_exists", return_value=False),
         mock.patch("odoo_tools.utils.git.run") as mock_run,
     ):
         result = git_utils.ensure_remote("/repo", "OCA", "git@github.com:OCA/foo.git")
@@ -108,7 +108,7 @@ def test_ensure_remote_adds_when_missing():
 
 def test_ensure_remote_skips_when_present():
     with (
-        mock.patch("odoo_tools.utils.git._remote_exists", return_value=True),
+        mock.patch("odoo_tools.utils.git.remote_exists", return_value=True),
         mock.patch("odoo_tools.utils.git.run") as mock_run,
     ):
         result = git_utils.ensure_remote("/repo", "OCA", "git@github.com:OCA/foo.git")
@@ -157,8 +157,10 @@ def test_fetch_targeted_warns_on_failure():
 
 def test_setup_submodule_remotes_with_project_id():
     with (
+        mock.patch("odoo_tools.utils.git.remote_exists", return_value=False),
         mock.patch("odoo_tools.utils.git.ensure_remote") as mock_ensure,
         mock.patch("odoo_tools.utils.git.fetch_targeted") as mock_fetch,
+        mock.patch("odoo_tools.utils.git.remote_repo_exists", return_value=True),
     ):
         git_utils.setup_submodule_remotes(
             "/cache/account-payment",
@@ -191,8 +193,10 @@ def test_setup_submodule_remotes_with_project_id():
 
 def test_setup_submodule_remotes_without_project_id():
     with (
+        mock.patch("odoo_tools.utils.git.remote_exists", return_value=False),
         mock.patch("odoo_tools.utils.git.ensure_remote") as mock_ensure,
         mock.patch("odoo_tools.utils.git.fetch_targeted") as mock_fetch,
+        mock.patch("odoo_tools.utils.git.remote_repo_exists", return_value=True),
     ):
         git_utils.setup_submodule_remotes(
             "/cache/account-payment",
@@ -210,6 +214,114 @@ def test_setup_submodule_remotes_without_project_id():
             "OCA",
             "+refs/heads/18.0:refs/remotes/OCA/18.0",
         )
+
+
+def test_setup_submodule_remotes_skips_missing_oca():
+    """Regression test for #230.
+
+    A non-OCA submodule (e.g. a private ``camptocamp/odoo-tools`` module) has no
+    ``OCA/odoo-tools`` counterpart, so the OCA remote must not be added. The
+    company remote, which does exist, is still set up.
+    """
+
+    def repo_exists(url):
+        return not url.startswith("git@github.com:OCA/")
+
+    with (
+        mock.patch("odoo_tools.utils.git.remote_exists", return_value=False),
+        mock.patch("odoo_tools.utils.git.ensure_remote") as mock_ensure,
+        mock.patch("odoo_tools.utils.git.fetch_targeted") as mock_fetch,
+        mock.patch("odoo_tools.utils.git.remote_repo_exists", side_effect=repo_exists),
+    ):
+        git_utils.setup_submodule_remotes(
+            "/cache/odoo-tools",
+            "git@github.com:camptocamp/odoo-tools.git",
+            "18.0",
+            "1289",
+            "camptocamp",
+        )
+        # OCA remote must NOT be added (OCA/odoo-tools does not exist)
+        mock_ensure.assert_called_once_with(
+            "/cache/odoo-tools",
+            "camptocamp",
+            "git@github.com:camptocamp/odoo-tools.git",
+        )
+        mock_fetch.assert_called_once_with(
+            "/cache/odoo-tools",
+            "camptocamp",
+            "+refs/heads/merge-branch-1289-*:refs/remotes/camptocamp/merge-branch-1289-*",
+        )
+
+
+def test_setup_submodule_remotes_skips_missing_company_fork():
+    """A submodule without a company fork must not get a dangling company remote."""
+
+    def repo_exists(url):
+        return url.startswith("git@github.com:OCA/")
+
+    with (
+        mock.patch("odoo_tools.utils.git.remote_exists", return_value=False),
+        mock.patch("odoo_tools.utils.git.ensure_remote") as mock_ensure,
+        mock.patch("odoo_tools.utils.git.fetch_targeted") as mock_fetch,
+        mock.patch("odoo_tools.utils.git.remote_repo_exists", side_effect=repo_exists),
+    ):
+        git_utils.setup_submodule_remotes(
+            "/cache/account-payment",
+            "git@github.com:OCA/account-payment.git",
+            "18.0",
+            "1289",
+            "camptocamp",
+        )
+        # Only the OCA remote is set up; the missing company fork is skipped
+        mock_ensure.assert_called_once_with(
+            "/cache/account-payment", "OCA", "git@github.com:OCA/account-payment.git"
+        )
+        mock_fetch.assert_called_once_with(
+            "/cache/account-payment",
+            "OCA",
+            "+refs/heads/18.0:refs/remotes/OCA/18.0",
+        )
+
+
+def test_setup_submodule_remotes_skips_probe_when_remote_present():
+    """When the remotes are already configured locally, skip the network probe."""
+    with (
+        mock.patch("odoo_tools.utils.git.remote_exists", return_value=True),
+        mock.patch("odoo_tools.utils.git.ensure_remote") as mock_ensure,
+        mock.patch("odoo_tools.utils.git.fetch_targeted") as mock_fetch,
+        mock.patch("odoo_tools.utils.git.remote_repo_exists") as mock_probe,
+    ):
+        git_utils.setup_submodule_remotes(
+            "/cache/account-payment",
+            "git@github.com:camptocamp/account-payment.git",
+            "18.0",
+            "1289",
+            "camptocamp",
+        )
+        # No network probe when both remotes are already present
+        mock_probe.assert_not_called()
+        # Both remotes are still (idempotently) ensured and re-fetched
+        assert mock_ensure.call_count == 2
+        assert mock_fetch.call_count == 2
+
+
+# ── remote_repo_exists ────────────────────────────────────────────────────────
+
+
+def test_remote_repo_exists_true():
+    git_utils.remote_repo_exists.cache_clear()
+    with mock.patch("subprocess.run", return_value=mock.Mock(returncode=0)) as mock_run:
+        assert git_utils.remote_repo_exists("git@github.com:OCA/account-payment.git")
+        mock_run.assert_called_once_with(
+            ["git", "ls-remote", "git@github.com:OCA/account-payment.git"],
+            capture_output=True,
+        )
+
+
+def test_remote_repo_exists_false():
+    git_utils.remote_repo_exists.cache_clear()
+    with mock.patch("subprocess.run", return_value=mock.Mock(returncode=128)):
+        assert not git_utils.remote_repo_exists("git@github.com:OCA/odoo-tools.git")
 
 
 # ── get_pinned_sha ────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Problem

`otools-submodule init/update` crashes with `ERROR: Repository not found.` on projects that contain non-OCA submodules (e.g. private `camptocamp/...` modules). See #230.

Commit 085dab6 added `setup_submodule_remotes()`, which builds an `OCA/<repo>` URL (and a `<company>/<repo>` URL) purely from the submodule name and registers them as remotes on **every** submodule. For a submodule whose `.gitmodules` URL is e.g. `git@github.com:camptocamp/odoo-tools.git`, there is no `OCA/odoo-tools` repository, so the freshly-added `OCA` remote is a dangling pointer.

That dangling remote is exactly what then breaks: git's fallback fetch iterates **all** remotes and dies with `Repository not found` — the very fallback path `setup_submodule_remotes()` was introduced to avoid.

## Fix

Probe each candidate remote URL with `git ls-remote` and only add + fetch it when the repository is actually reachable (`ls-remote` exits `0` when it exists, `128` when missing).

- The guard is applied symmetrically to both the `OCA` and the `<company>` remote — a missing company fork would reintroduce the identical dangling-remote bug.
- The probe is memoized (`lru_cache`) because `setup_submodule_remotes()` runs twice per submodule (autoshare cache + working tree), so each repo is probed at most once per run.
- Legitimate cases are preserved: `camptocamp/account-payment` still gets its `OCA/account-payment` remote, because that upstream really exists.

## Tests

- Existing `setup_submodule_remotes` tests now patch `remote_repo_exists` (assertions unchanged).
- New regression test for the #230 case (non-OCA submodule → no bogus `OCA` remote).
- New test for a submodule without a company fork (no dangling company remote).
- New unit tests for `remote_repo_exists`.

Full suite: 337 passed, 2 xfailed. pre-commit (ruff check/format, codespell) clean.

## Note

`remote_repo_exists` makes one `git ls-remote` network round-trip per distinct repo URL during an update (cached per run). On projects with many submodules this adds some latency; happy to short-circuit (e.g. skip the OCA probe when the submodule owner is already OCA) if preferred.

Closes #230
