### PR TITLE
[REF] utils: dedupe get_current_branch

### DIFF
--- a/odoo_tools/utils/gh.py
+++ b/odoo_tools/utils/gh.py
@@ -5,7 +5,7 @@ import re
 import subprocess
 from pathlib import Path
 
-from . import ui
+from . import git, ui
 from .os_exec import run
 from .proj import get_project_manifest_key
 
@@ -90,10 +90,6 @@ def get_current_rebase_branch():
     return current_branch
 
 
-def get_current_branch():
-    return run("git symbolic-ref --short HEAD")
-
-
 def get_target_branch(target_branch=None):
     """Gets the branch to push on and checks if we're overriding something.
 
@@ -102,7 +98,7 @@ def get_target_branch(target_branch=None):
     """
     current_branch = get_current_rebase_branch()
     if not current_branch:
-        current_branch = get_current_branch()
+        current_branch = git.get_current_branch()
     project_id = get_project_manifest_key("project_id")
     if not target_branch:
         commit = run("git rev-parse HEAD")[:8]

--- a/odoo_tools/utils/git.py
+++ b/odoo_tools/utils/git.py
@@ -320,13 +320,11 @@ def checkout(branch_name, remote="origin"):
 
 
 def get_current_branch():
+    """Return the current branch name, or None when not on a branch."""
     try:
-        branch = subprocess.check_output(
-            ["git", "branch", "--show-current"], text=True
-        ).strip()
+        return run(["git", "branch", "--show-current"], check=True) or None
     except subprocess.CalledProcessError:
-        branch = None
-    return branch
+        return None
 
 
 def delete_branch(branch_name):

--- a/tests/test_utils_gh.py
+++ b/tests/test_utils_gh.py
@@ -83,15 +83,6 @@ class TestParseGithubUrl:
 
 @pytest.mark.project_setup(git_init=True)
 @pytest.mark.usefixtures("project")
-class TestGetCurrentBranch:
-    def test_returns_branch_name(self):
-        repo = git.Repo(".")
-        repo.create_head("my-feature").checkout()
-        assert gh_utils.get_current_branch() == "my-feature"
-
-
-@pytest.mark.project_setup(git_init=True)
-@pytest.mark.usefixtures("project")
 class TestGetCurrentRebaseBranch:
     def test_returns_none_when_no_rebase(self):
         assert gh_utils.get_current_rebase_branch() is None

--- a/tests/test_utils_git.py
+++ b/tests/test_utils_git.py
@@ -5,6 +5,7 @@ import subprocess
 from pathlib import Path
 from unittest import mock
 
+import git
 import pytest
 
 from odoo_tools.utils import git as git_utils
@@ -366,3 +367,15 @@ def test_submodule_update_pins_commit_after_clone(project, tmp_path):
     mock_pin.assert_called_once()
     call_args = mock_pin.call_args[0]
     assert call_args[1] == pinned_sha
+
+
+# ── get_current_branch ────────────────────────────────────────────────────────
+
+
+@pytest.mark.project_setup(git_init=True)
+@pytest.mark.usefixtures("project")
+class TestGetCurrentBranch:
+    def test_returns_branch_name(self):
+        repo = git.Repo(".")
+        repo.create_head("my-feature").checkout()
+        assert git_utils.get_current_branch() == "my-feature"


### PR DESCRIPTION
## What

There were two implementations of `get_current_branch`:

- `utils/git.py` — via `subprocess.check_output(["git", "branch", "--show-current"])`
- `utils/gh.py` — via `os_exec.run("git symbolic-ref --short HEAD")`

They behaved differently on a detached HEAD, and having the same helper in two
modules is a maintenance trap.

This keeps a single canonical implementation in `utils/git.py`, routed through
the `os_exec.run` wrapper for consistency with the rest of the module. Callers
use it from `git.py` directly (`utils/gh.py` now calls `git.get_current_branch`
internally); there is no re-export. The existing test moves alongside the other
`git` util tests.

## Testing

`pytest` full suite green (333 passed, 2 xfailed).