### PR TITLE
[REF] pending_merge: call gitaggregate CLI instead of importing git_aggregator

### DIFF
--- a/odoo_tools/cli/pending.py
+++ b/odoo_tools/cli/pending.py
@@ -208,9 +208,8 @@ def clean_pending(repo_paths=(), aggregate=True):
         if not repo.has_any_pr_left():
             repo._handle_empty_merges_file(delete_file=True)
         elif aggregate:
-            aggregator = repo.get_aggregator()
-            aggregator.aggregate()
-            aggregator.push()
+            repo.run_aggregate()
+            repo.push_to_remote()
 
 
 # TODO: add tests
@@ -232,10 +231,9 @@ def clean_pending(repo_paths=(), aggregate=True):
 def aggregate(repo_path, target_branch=None, push=None):
     """Perform a git aggregation on <repo_path>."""
     repo = pm_utils.Repo(repo_path)
-    aggregator = repo.get_aggregator(target_branch=target_branch)
-    aggregator.aggregate()
+    repo.run_aggregate()
     if push:
-        aggregator.push()
+        repo.push_to_remote(target_branch=target_branch)
 
 
 @cli.command(name="add")
@@ -278,10 +276,9 @@ def add_pending(entity_urls, aggregate=True, patch=False, push=True):
     # Then aggregate each affected submodule once.
     if aggregate:
         for repo in repos.values():
-            aggregator = repo.get_aggregator()
-            aggregator.aggregate()
+            repo.run_aggregate()
             if push:
-                aggregator.push()
+                repo.push_to_remote()
 
 
 @cli.command(name="remove")

--- a/odoo_tools/utils/git.py
+++ b/odoo_tools/utils/git.py
@@ -49,6 +49,18 @@ def remote_repo_exists(url: str) -> bool:
     return result.returncode == 0
 
 
+def get_remotes(git_dir: str | Path) -> dict[str, str]:
+    """Return the repo's remotes as a mapping of remote name to fetch URL."""
+    output = run(["git", "-C", str(git_dir), "remote", "-v"], check=True)
+    remotes = {}
+    for line in output.splitlines():
+        name, url_and_kind = line.split("\t")
+        url, _, kind = url_and_kind.rpartition(" ")
+        if kind == "(fetch)":
+            remotes[name] = url
+    return remotes
+
+
 def ensure_remote(git_dir: str | Path, remote_name: str, url: str) -> bool:
     """Add a named remote if it doesn't already exist.
 

--- a/odoo_tools/utils/pending_merge.py
+++ b/odoo_tools/utils/pending_merge.py
@@ -9,9 +9,6 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 import click
-import git_aggregator.config
-import git_aggregator.main
-import git_aggregator.repo
 import requests
 from ruamel.yaml.comments import CommentedMap, CommentedSeq
 
@@ -19,6 +16,7 @@ from ..exceptions import PathNotFound
 from ..utils.misc import SmartDict, get_docker_image_commit_hashes
 from . import gh, git, ui
 from .config import config
+from .os_exec import run
 from .path import build_path, cd
 from .proj import get_project_manifest_key
 from .yaml import (
@@ -30,8 +28,6 @@ from .yaml import (
 )
 
 logger = logging.getLogger(__name__)
-
-git_aggregator.main.setup_logger()
 
 
 @dataclass(kw_only=True)
@@ -487,17 +483,26 @@ class Repo:
         self.update_merges_config(conf)
 
     # aggregator API
-    # TODO: add tests
-    def get_aggregator(self, target_remote=None, target_branch=None, **extra_config):
-        if "target" not in extra_config:
-            extra_config["target"] = {}
-        target_branch = target_branch or gh.get_target_branch()
-        if target_branch and "branch" not in extra_config["target"]:
-            extra_config["target"]["branch"] = target_branch
-        target_remote = target_remote or self.company_git_remote
-        if target_remote and "remote" not in extra_config["target"]:
-            extra_config["target"]["remote"] = target_remote
-        return RepoAggregator(self, **extra_config)
+    def run_aggregate(self, **kwargs):
+        """Aggregate the pending merges using the git-aggregator CLI.
+
+        The aggregation happens on the local branch declared as ``target`` in
+        the merges file, which acts as a local scratch branch: pushing the
+        result to a permanent, dynamically named remote branch is handled
+        separately by :meth:`push_to_remote`.
+
+        Extra keyword arguments are passed through to :func:`run`.
+        """
+        # The merges file keys are paths relative to the pending-merges
+        # folder (e.g. ``../odoo/external-src/<name>``), and gitaggregate
+        # resolves them against the process working directory.
+        kwargs.setdefault("cwd", self.pending_merge_abs_path)
+        kwargs.setdefault("check", True)
+        kwargs.setdefault("verbose", True)
+        run(
+            ["gitaggregate", "--config", str(self.abs_merges_path), "aggregate"],
+            **kwargs,
+        )
 
     def _iter_pending_pull_requests(self) -> Iterator[PendingPR]:
         merges_config = self.merges_config()
@@ -607,8 +612,7 @@ class Repo:
             choice = ui.ask_question(msg, default=default_choice)
         opt = next(opt for opt in sorted_options if opt.choice == choice)
         if opt.remote:
-            # FIXME: use an internal util to get remotes
-            remotes = self.get_aggregator()._get_remotes()
+            remotes = git.get_remotes(self.abs_path)
             new_remote_url = get_new_remote_url(repo=self, force_remote=opt.remote)
             if opt.remote not in remotes:
                 ui.echo(f"Adding missing remote: {opt.remote} -> {new_remote_url}")
@@ -628,26 +632,29 @@ class Repo:
             self.abs_merges_path.unlink()
 
     def push_to_remote(self, target_branch=None):
+        """Push the aggregated HEAD to the company remote as ``target_branch``.
+
+        The branch name embeds the project commit hash, giving the aggregated
+        commit a permanent ref on the fork so that submodule pins referencing
+        it always stay fetchable.
+        """
         target_branch = target_branch or gh.get_target_branch()
-        aggregator = self.get_aggregator(target_branch=target_branch)
-        with cd(self.abs_path):
-            aggregator._switch_to_branch(target_branch)
-            aggregator.push()
+        git.ensure_remote(
+            self.abs_path,
+            self.company_git_remote,
+            self.ssh_url(self.company_git_remote),
+        )
+        run(
+            f"git push -f {self.company_git_remote} HEAD:refs/heads/{target_branch}",
+            cwd=self.abs_path,
+            check=True,
+            verbose=True,
+        )
 
     def rebuild_consolidation_branch(self, push=False):
-        aggregator = self.get_aggregator()
-        aggregator.aggregate()
+        self.run_aggregate()
         if push:
-            aggregator.push()
-
-
-class RepoAggregator(git_aggregator.repo.Repo):
-    def __init__(self, repo, **extra_config):
-        self.pm_repo = repo
-        config = git_aggregator.config.load_config(self.pm_repo.abs_merges_path)[0]
-        config.update(extra_config)
-        super().__init__(**config)
-        self.cwd = self.pm_repo.abs_path
+            self.push_to_remote()
 
 
 def add_pending(entity_url, aggregate=True, patch=False, push=True):
@@ -689,10 +696,9 @@ def add_pending(entity_url, aggregate=True, patch=False, push=True):
     elif entity_type in ("commit", "tree"):
         repo.add_pending_commit(upstream, entity_id)
     if aggregate:
-        aggregator = repo.get_aggregator()
-        aggregator.aggregate()
+        repo.run_aggregate()
         if push:
-            aggregator.push()
+            repo.push_to_remote()
     return repo
 
 
@@ -714,8 +720,7 @@ def remove_pending(entity_url, aggregate=True):
     if not repo.has_any_pr_left():
         repo._handle_empty_merges_file(delete_file=True)
     elif aggregate:
-        aggregator = repo.get_aggregator()
-        aggregator.aggregate()
+        repo.run_aggregate()
     return repo
 
 

--- a/tests/test_utils_git.py
+++ b/tests/test_utils_git.py
@@ -117,6 +117,27 @@ def test_ensure_remote_skips_when_present():
         mock_run.assert_not_called()
 
 
+# ── get_remotes ───────────────────────────────────────────────────────────────
+
+
+def test_get_remotes():
+    output = (
+        "OCA\tgit@github.com:OCA/edi.git (fetch)\n"
+        "OCA\tgit@github.com:OCA/edi.git (push)\n"
+        "camptocamp\tgit@github.com:camptocamp/edi.git (fetch)\n"
+        "camptocamp\tgit@github.com:camptocamp/edi.git (push)"
+    )
+    with mock.patch("odoo_tools.utils.git.run", return_value=output) as mock_run:
+        remotes = git_utils.get_remotes("/repo")
+        mock_run.assert_called_once_with(
+            ["git", "-C", "/repo", "remote", "-v"], check=True
+        )
+    assert remotes == {
+        "OCA": "git@github.com:OCA/edi.git",
+        "camptocamp": "git@github.com:camptocamp/edi.git",
+    }
+
+
 # ── fetch_targeted ────────────────────────────────────────────────────────────
 
 

--- a/tests/test_utils_pending_merge.py
+++ b/tests/test_utils_pending_merge.py
@@ -763,7 +763,6 @@ def test_cli_add_multiple_urls_aggregates_once_per_submodule(project):
     when several URLs target the same submodule (no intermediate aggregation)."""
     mock_pending_merge_repo_paths("edi")
     mock_pending_merge_repo_paths("web")
-    aggregator = mock.MagicMock()
     with responses.RequestsMock() as rsps:
         # match the project's odoo_version so no divergent-branch prompt
         for pull_id in (1470, 1471):
@@ -779,9 +778,10 @@ def test_cli_add_multiple_urls_aggregates_once_per_submodule(project):
             json={"base": {"ref": "14.0"}},
             status=200,
         )
-        with mock.patch.object(
-            pm_utils.Repo, "get_aggregator", return_value=aggregator
-        ) as get_aggregator:
+        with (
+            mock.patch.object(pm_utils.Repo, "run_aggregate") as run_aggregate,
+            mock.patch.object(pm_utils.Repo, "push_to_remote") as push_to_remote,
+        ):
             result = project.invoke(
                 pending.add_pending,
                 [
@@ -793,9 +793,40 @@ def test_cli_add_multiple_urls_aggregates_once_per_submodule(project):
             )
     assert result.exit_code == 0
     # edi is referenced twice but aggregated once: 2 unique submodules total.
-    assert get_aggregator.call_count == 2
-    assert aggregator.aggregate.call_count == 2
-    assert aggregator.push.call_count == 2
+    assert run_aggregate.call_count == 2
+    assert push_to_remote.call_count == 2
+
+
+def test_repo_run_aggregate_runs_gitaggregate_cli(project):
+    mock_pending_merge_repo_paths("edi")
+    repo = Repo("edi", path_check=False)
+    with mock.patch.object(pm_utils, "run") as run:
+        repo.run_aggregate()
+    run.assert_called_once_with(
+        ["gitaggregate", "--config", str(repo.abs_merges_path), "aggregate"],
+        cwd=repo.pending_merge_abs_path,
+        check=True,
+        verbose=True,
+    )
+
+
+def test_repo_push_to_remote(project):
+    mock_pending_merge_repo_paths("edi")
+    repo = Repo("edi", path_check=False)
+    with (
+        mock.patch.object(pm_utils, "run") as run,
+        mock.patch.object(pm_utils.git, "ensure_remote") as ensure_remote,
+    ):
+        repo.push_to_remote(target_branch="merge-branch-1234-master-abc12345")
+    ensure_remote.assert_called_once_with(
+        repo.abs_path, "camptocamp", "git@github.com:camptocamp/edi.git"
+    )
+    run.assert_called_once_with(
+        "git push -f camptocamp HEAD:refs/heads/merge-branch-1234-master-abc12345",
+        cwd=repo.abs_path,
+        check=True,
+        verbose=True,
+    )
 
 
 def test_iter_pending_pull_requests(project):


### PR DESCRIPTION
The `git_aggregator` library was only imported to override the aggregation target with a dynamically named branch (`merge-branch-<project>-<branch>-<sha8>`), which the `gitaggregate` CLI can't do.

Instead, we now aggregate without pushing (the target branch declared in the merges file acts as a local scratch branch), and push the result ourselves with plain git: `git push -f <remote> HEAD:refs/heads/<branch>` — the same pattern already used by the release command.

Changes:

- `Repo.get_aggregator()` and `RepoAggregator` are replaced by `Repo.run_aggregate()`, which runs the `gitaggregate` CLI as a subprocess (with `cwd=pending-merges.d` so the relative config keys resolve correctly).
- `Repo.push_to_remote()` now ensures the company remote and pushes `HEAD` with plain git; no local branch switching, no private library API.
- The private `_get_remotes()` usage is replaced by a new `git.get_remotes()` helper (resolves a long-standing FIXME).
- `git-aggregator` stays as a dependency: it provides the executable.

Side effect: aggregating without pushing no longer prompts for target-branch confirmation, since the target branch is only relevant when pushing.