### PR TITLE
[ADD] addon: list, depends and codepends commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,8 +112,11 @@ Options:
   --help  Show this message and exit.
 
 Commands:
-  add-req  Generate a python requirement line.
-  where    Locate an addon by name across the project's addon directories.
+  add-req    Generate a python requirement line.
+  codepends  List the co-dependencies of the given addons.
+  depends    List the dependencies of the given addons.
+  list       List the project's local addons.
+  where      Locate an addon by name across the project's addon directories.
 ```
 
 #### otools-addon add-req
@@ -155,6 +158,67 @@ Usage: otools-addon where [OPTIONS] NAME
 
 Options:
   --help  Show this message and exit.
+```
+
+#### otools-addon list
+
+```
+Usage: otools-addon list [OPTIONS]
+
+  List the project's local addons.
+
+Options:
+  --separator TEXT  Separator to join the addon names with (by default, print
+                    one per line).
+  --help            Show this message and exit.
+```
+
+#### otools-addon depends
+
+```
+Usage: otools-addon depends [OPTIONS] [ADDONS]...
+
+  List the dependencies of the given addons.
+
+  Addons can be passed as multiple arguments or as comma separated lists. When
+  no addon is given, the project's local addons are selected.
+
+Options:
+  --transitive        Print all transitive dependencies.
+  --include-selected  Print the selected addons along with their dependencies.
+  --ignore-missing    Only warn about addons not found in the addons
+                      directories, instead of failing.
+  --quiet             Do not print warnings about missing addons.
+  --separator TEXT    Separator to join the addon names with (by default,
+                      print one per line).
+  --help              Show this message and exit.
+```
+
+For example, to list all the addons used by the project:
+
+    otools-addon depends --transitive --include-selected
+
+#### otools-addon codepends
+
+```
+Usage: otools-addon codepends [OPTIONS] ADDONS...
+
+  List the co-dependencies of the given addons.
+
+  Co-dependencies are the addons that depend on the given addons. Addons can
+  be passed as multiple arguments or as comma separated lists.
+
+Options:
+  --transitive / --no-transitive  Print all transitive co-dependencies.
+  --include-selected / --no-include-selected
+                                  Print the selected addons along with their
+                                  co-dependencies.
+  --ignore-missing                Only warn about addons not found in the
+                                  addons directories, instead of failing.
+  --quiet                         Do not print warnings about missing addons.
+  --separator TEXT                Separator to join the addon names with (by
+                                  default, print one per line).
+  --help                          Show this message and exit.
 ```
 
 ### otools-db

--- a/odoo_tools/cli/addon.py
+++ b/odoo_tools/cli/addon.py
@@ -4,6 +4,7 @@
 
 import click
 
+from ..utils import manifestoo as manifestoo_utils
 from ..utils import req as req_utils
 from ..utils import ui
 from ..utils.click import global_command_decorators
@@ -103,6 +104,125 @@ def where(name):
         ui.exit_msg(f"Addon '{name}' not found")
     for path in found:
         click.echo(path)
+
+
+@cli.command(name="list")
+@click.option(
+    "--separator",
+    help="Separator to join the addon names with (by default, print one per line).",
+)
+def list_addons(separator):
+    """List the project's local addons."""
+    addons_set = manifestoo_utils.get_addons_set()
+    selection = manifestoo_utils.get_local_addons_selection()
+    addon_names = manifestoo_utils.list_addons(selection, addons_set)
+    if addon_names:
+        click.echo((separator or "\n").join(addon_names))
+
+
+@cli.command()
+@click.argument("addons", nargs=-1)
+@click.option(
+    "--transitive",
+    is_flag=True,
+    help="Print all transitive dependencies.",
+)
+@click.option(
+    "--include-selected",
+    is_flag=True,
+    help="Print the selected addons along with their dependencies.",
+)
+@click.option(
+    "--ignore-missing",
+    is_flag=True,
+    help="Only warn about addons not found in the addons directories, "
+    "instead of failing.",
+)
+@click.option(
+    "--quiet",
+    is_flag=True,
+    help="Do not print warnings about missing addons.",
+)
+@click.option(
+    "--separator",
+    help="Separator to join the addon names with (by default, print one per line).",
+)
+def depends(addons, transitive, include_selected, ignore_missing, quiet, separator):
+    """List the dependencies of the given addons.
+
+    Addons can be passed as multiple arguments or as comma separated lists.
+    When no addon is given, the project's local addons are selected.
+    """
+    addons_set = manifestoo_utils.get_addons_set()
+    if addons:
+        selection = manifestoo_utils.get_addons_selection(addons)
+    else:
+        selection = manifestoo_utils.get_local_addons_selection()
+    addon_names, missing = manifestoo_utils.list_depends(
+        selection,
+        addons_set,
+        transitive=transitive,
+        include_selected=include_selected,
+        ignore_missing=ignore_missing,
+    )
+    if missing and not quiet:
+        ui.err_console.print(
+            f"Warning: addon(s) not found: {', '.join(missing)}",
+            style="yellow",
+        )
+    if addon_names:
+        click.echo((separator or "\n").join(addon_names))
+
+
+@cli.command()
+@click.argument("addons", nargs=-1, required=True)
+@click.option(
+    "--transitive/--no-transitive",
+    default=True,
+    help="Print all transitive co-dependencies.",
+)
+@click.option(
+    "--include-selected/--no-include-selected",
+    default=True,
+    help="Print the selected addons along with their co-dependencies.",
+)
+@click.option(
+    "--ignore-missing",
+    is_flag=True,
+    help="Only warn about addons not found in the addons directories, "
+    "instead of failing.",
+)
+@click.option(
+    "--quiet",
+    is_flag=True,
+    help="Do not print warnings about missing addons.",
+)
+@click.option(
+    "--separator",
+    help="Separator to join the addon names with (by default, print one per line).",
+)
+def codepends(addons, transitive, include_selected, ignore_missing, quiet, separator):
+    """List the co-dependencies of the given addons.
+
+    Co-dependencies are the addons that depend on the given addons.
+    Addons can be passed as multiple arguments or as comma separated lists.
+    """
+    addons_set = manifestoo_utils.get_addons_set()
+    selection = manifestoo_utils.get_addons_selection(addons)
+    addon_names, missing = manifestoo_utils.list_codepends(
+        selection,
+        addons_set,
+        transitive=transitive,
+        include_selected=include_selected,
+        ignore_missing=ignore_missing,
+    )
+    if missing and not quiet:
+        ui.err_console.print(
+            f"Warning: addon(s) not found: {', '.join(missing)}",
+            style="yellow",
+        )
+    if addon_names:
+        click.echo((separator or "\n").join(addon_names))
 
 
 if __name__ == "__main__":

--- a/odoo_tools/utils/manifestoo.py
+++ b/odoo_tools/utils/manifestoo.py
@@ -1,0 +1,122 @@
+# Copyright 2026 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from pathlib import Path
+
+from manifestoo.addons_selection import AddonsSelection
+from manifestoo.commands.list import list_command
+from manifestoo.commands.list_codepends import list_codepends_command
+from manifestoo.commands.list_depends import list_depends_command
+from manifestoo_core.addons_set import AddonsSet
+
+from . import ui
+from .config import config
+from .path import build_path
+
+
+def get_addons_dirs() -> list[Path]:
+    """Return all the directories where the project's addons are located."""
+    addons_dirs = []
+    # local-src: addons are direct children
+    addons_dirs.append(build_path(config.local_src_rel_path))
+    # external-src: each subdirectory is a repo containing addons
+    ext_src = build_path(config.ext_src_rel_path)
+    if ext_src.is_dir():
+        for repo_dir in sorted(ext_src.iterdir()):
+            if repo_dir.is_dir():
+                addons_dirs.append(repo_dir)
+    # Odoo community and base addons
+    odoo_src = build_path(config.odoo_src_rel_path)
+    addons_dirs.append(odoo_src / "addons")
+    addons_dirs.append(odoo_src / "odoo" / "addons")
+    return addons_dirs
+
+
+def get_addons_set() -> AddonsSet:
+    """Return the set of all addons found in the project's addons directories."""
+    addons_set = AddonsSet()
+    addons_set.add_from_addons_dirs(get_addons_dirs())
+    return addons_set
+
+
+def get_local_addons_selection() -> AddonsSelection:
+    """Return a selection holding the project's local addons."""
+    selection = AddonsSelection()
+    selection.add_addons_dirs([build_path(config.local_src_rel_path)])
+    return selection
+
+
+def get_addons_selection(addon_names: Iterable[str]) -> AddonsSelection:
+    """Return a selection holding the given addon names.
+
+    Each name may itself be a comma separated list of addon names.
+    """
+    selection = AddonsSelection()
+    for addon_name in addon_names:
+        selection.add_addon_names(addon_name)
+    return selection
+
+
+def list_addons(
+    selection: AddonsSelection,
+    addons_set: AddonsSet,
+) -> list[str]:
+    """Return the names of the selected addons."""
+    return list(list_command(selection, addons_set))
+
+
+def list_depends(
+    selection: AddonsSelection,
+    addons_set: AddonsSet,
+    transitive: bool = False,
+    include_selected: bool = False,
+    ignore_missing: bool = False,
+) -> tuple[list[str], list[str]]:
+    """Return the dependencies of the selected addons.
+
+    Returns a tuple ``(addon_names, missing_addon_names)`` where the second
+    item holds the addons that were not found in the addons directories.
+    Missing addons raise an error, unless ``ignore_missing`` is set.
+    """
+    addon_names, missing = list_depends_command(
+        selection,
+        addons_set,
+        transitive=transitive,
+        include_selected=include_selected,
+    )
+    if missing and not ignore_missing:
+        ui.exit_msg(f"Addon(s) not found: {', '.join(sorted(missing))}")
+    return list(addon_names), sorted(missing)
+
+
+def list_codepends(
+    selection: AddonsSelection,
+    addons_set: AddonsSet,
+    transitive: bool = True,
+    include_selected: bool = True,
+    ignore_missing: bool = False,
+) -> tuple[list[str], list[str]]:
+    """Return the co-dependencies of the selected addons.
+
+    Co-dependencies are the addons that depend on the selected addons.
+
+    Returns a tuple ``(addon_names, missing_addon_names)`` where the second
+    item holds the selected addons that were not found in the addons
+    directories. Missing addons raise an error, unless ``ignore_missing``
+    is set.
+    """
+    missing = sorted(selection - addons_set.keys())
+    if missing and not ignore_missing:
+        ui.exit_msg(f"Addon(s) not found: {', '.join(missing)}")
+    addon_names = list(
+        list_codepends_command(
+            selection,
+            addons_set,
+            transitive=transitive,
+            include_selected=include_selected,
+        )
+    )
+    return addon_names, missing

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
     "bump-my-version",
     "requirements-parser>=0.13.1",
     "Jinja2",
+    "manifestoo",
     ]
 requires-python = ">=3.10"
 dynamic = ["version"]

--- a/tests/common.py
+++ b/tests/common.py
@@ -161,6 +161,21 @@ def fake_bundle_addon(source_template_path=None, **kwargs):
         file.rename(file.with_suffix(""))
 
 
+def make_fake_addon(
+    path, depends=(), installable=True, manifest_filename="__manifest__.py"
+):
+    """Create a fake addon directory with a valid manifest file."""
+    path = Path(path)
+    path.mkdir(parents=True, exist_ok=True)
+    manifest = {
+        "name": path.name,
+        "depends": list(depends),
+        "installable": installable,
+    }
+    (path / manifest_filename).write_text(repr(manifest))
+    (path / "__init__.py").touch()
+
+
 def compare_line_by_line(content, expected, sort=False):
     content_lines = [x.strip() for x in content.splitlines() if x.strip()]
     expected_lines = [x.strip() for x in expected.splitlines() if x.strip()]

--- a/tests/test_addon_depends.py
+++ b/tests/test_addon_depends.py
@@ -1,0 +1,203 @@
+# Copyright 2026 Camptocamp SA (https://www.camptocamp.com).
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+import pytest
+
+from odoo_tools.cli import addon
+from odoo_tools.utils.config import config
+
+from .common import make_fake_addon
+
+
+@pytest.fixture()
+def project_addons(project):
+    """A fake project with a small addon dependency tree."""
+    make_fake_addon(config.odoo_src_rel_path / "odoo" / "addons" / "base")
+    make_fake_addon(
+        config.ext_src_rel_path / "some_repo" / "oca_base_addon", depends=["base"]
+    )
+    make_fake_addon(
+        config.ext_src_rel_path / "some_repo" / "oca_addon",
+        depends=["oca_base_addon", "base"],
+    )
+    make_fake_addon(
+        config.local_src_rel_path / "my_addon", depends=["oca_addon", "base"]
+    )
+    make_fake_addon(config.local_src_rel_path / "other_addon", depends=["my_addon"])
+    return project
+
+
+def test_list(project_addons):
+    result = project_addons.invoke(addon.list_addons)
+    assert result.exit_code == 0
+    assert result.output.splitlines() == ["my_addon", "other_addon"]
+
+
+def test_list_separator(project_addons):
+    result = project_addons.invoke(addon.list_addons, "--separator ,")
+    assert result.exit_code == 0
+    assert result.output.splitlines() == ["my_addon,other_addon"]
+
+
+def test_list_excludes_not_installable(project_addons):
+    make_fake_addon(config.local_src_rel_path / "wip_addon", installable=False)
+    result = project_addons.invoke(addon.list_addons)
+    assert result.exit_code == 0
+    assert "wip_addon" not in result.output
+
+
+def test_depends_direct(project_addons):
+    result = project_addons.invoke(addon.depends, "my_addon")
+    assert result.exit_code == 0
+    assert result.output.splitlines() == ["base", "oca_addon"]
+
+
+def test_depends_transitive(project_addons):
+    result = project_addons.invoke(addon.depends, "my_addon --transitive")
+    assert result.exit_code == 0
+    assert result.output.splitlines() == ["base", "oca_addon", "oca_base_addon"]
+
+
+def test_depends_include_selected(project_addons):
+    result = project_addons.invoke(addon.depends, "my_addon --include-selected")
+    assert result.exit_code == 0
+    assert result.output.splitlines() == ["base", "my_addon", "oca_addon"]
+
+
+def test_depends_multiple_addons(project_addons):
+    result = project_addons.invoke(addon.depends, "my_addon other_addon")
+    assert result.exit_code == 0
+    assert result.output.splitlines() == ["base", "oca_addon"]
+
+
+def test_depends_comma_separated(project_addons):
+    result = project_addons.invoke(addon.depends, "my_addon,other_addon")
+    assert result.exit_code == 0
+    assert result.output.splitlines() == ["base", "oca_addon"]
+
+
+def test_depends_no_addons_selects_local_src(project_addons):
+    result = project_addons.invoke(addon.depends)
+    assert result.exit_code == 0
+    assert result.output.splitlines() == ["base", "oca_addon"]
+
+
+def test_depends_no_addons_transitive_include_selected(project_addons):
+    """List all the addons used by the project."""
+    result = project_addons.invoke(addon.depends, "--transitive --include-selected")
+    assert result.exit_code == 0
+    assert result.output.splitlines() == [
+        "base",
+        "my_addon",
+        "oca_addon",
+        "oca_base_addon",
+        "other_addon",
+    ]
+
+
+def test_depends_unknown_addon(project_addons):
+    result = project_addons.invoke(addon.depends, "nonexistent_addon")
+    assert result.exit_code != 0
+    assert "not found" in result.output.lower()
+
+
+def test_depends_fails_on_missing_dependencies(project_addons):
+    make_fake_addon(config.local_src_rel_path / "broken_addon", depends=["ghost"])
+    result = project_addons.invoke(addon.depends, "broken_addon --transitive")
+    assert result.exit_code != 0
+    assert "not found" in result.output.lower()
+    assert "ghost" in result.output
+
+
+def test_depends_ignore_missing_warns_about_missing_dependencies(project_addons):
+    make_fake_addon(config.local_src_rel_path / "broken_addon", depends=["ghost"])
+    result = project_addons.invoke(
+        addon.depends, "broken_addon --transitive --ignore-missing"
+    )
+    assert result.exit_code == 0
+    assert result.stdout.splitlines() == ["ghost"]
+    assert "not found" in result.stderr
+    assert "ghost" in result.stderr
+
+
+def test_depends_quiet_hides_missing_addons_warning(project_addons):
+    make_fake_addon(config.local_src_rel_path / "broken_addon", depends=["ghost"])
+    result = project_addons.invoke(
+        addon.depends, "broken_addon --transitive --ignore-missing --quiet"
+    )
+    assert result.exit_code == 0
+    assert result.stdout.splitlines() == ["ghost"]
+    assert result.stderr == ""
+
+
+def test_depends_separator(project_addons):
+    result = project_addons.invoke(addon.depends, "my_addon --separator ,")
+    assert result.exit_code == 0
+    assert result.output.splitlines() == ["base,oca_addon"]
+
+
+def test_codepends_default(project_addons):
+    result = project_addons.invoke(addon.codepends, "oca_base_addon")
+    assert result.exit_code == 0
+    assert result.output.splitlines() == [
+        "my_addon",
+        "oca_addon",
+        "oca_base_addon",
+        "other_addon",
+    ]
+
+
+def test_codepends_no_transitive(project_addons):
+    result = project_addons.invoke(addon.codepends, "oca_base_addon --no-transitive")
+    assert result.exit_code == 0
+    assert result.output.splitlines() == ["oca_addon", "oca_base_addon"]
+
+
+def test_codepends_no_include_selected(project_addons):
+    result = project_addons.invoke(
+        addon.codepends, "oca_base_addon --no-include-selected"
+    )
+    assert result.exit_code == 0
+    assert result.output.splitlines() == ["my_addon", "oca_addon", "other_addon"]
+
+
+def test_codepends_multiple_addons(project_addons):
+    result = project_addons.invoke(
+        addon.codepends, "oca_addon,base --no-transitive --no-include-selected"
+    )
+    assert result.exit_code == 0
+    assert result.output.splitlines() == ["my_addon", "oca_base_addon"]
+
+
+def test_codepends_unknown_addon(project_addons):
+    result = project_addons.invoke(addon.codepends, "nonexistent_addon")
+    assert result.exit_code != 0
+    assert "not found" in result.output.lower()
+
+
+def test_codepends_ignore_missing_warns_about_unknown_addon(project_addons):
+    result = project_addons.invoke(
+        addon.codepends, "nonexistent_addon --ignore-missing --no-include-selected"
+    )
+    assert result.exit_code == 0
+    assert result.stdout.splitlines() == []
+    assert "not found" in result.stderr
+    assert "nonexistent_addon" in result.stderr
+
+
+def test_codepends_quiet_hides_missing_addons_warning(project_addons):
+    result = project_addons.invoke(
+        addon.codepends,
+        "nonexistent_addon --ignore-missing --no-include-selected --quiet",
+    )
+    assert result.exit_code == 0
+    assert result.stdout.splitlines() == []
+    assert result.stderr == ""
+
+
+def test_codepends_separator(project_addons):
+    result = project_addons.invoke(addon.codepends, "oca_base_addon --separator ,")
+    assert result.exit_code == 0
+    assert result.output.splitlines() == [
+        "my_addon,oca_addon,oca_base_addon,other_addon"
+    ]

--- a/tests/test_addon_where.py
+++ b/tests/test_addon_where.py
@@ -1,42 +1,35 @@
 # Copyright 2024 Camptocamp SA (https://www.camptocamp.com).
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
-from pathlib import Path
-
 from odoo_tools.cli import addon
 from odoo_tools.utils.config import config
 
-
-def _make_addon(path, manifest="__manifest__.py"):
-    """Create a minimal addon directory with a manifest file."""
-    path = Path(path)
-    path.mkdir(parents=True, exist_ok=True)
-    (path / manifest).write_text("{}")
+from .common import make_fake_addon
 
 
 def test_where_found_in_local_src(project):
-    _make_addon(config.local_src_rel_path / "my_addon")
+    make_fake_addon(config.local_src_rel_path / "my_addon")
     result = project.invoke(addon.where, "my_addon")
     assert result.exit_code == 0
     assert str(config.local_src_rel_path / "my_addon") in result.output
 
 
 def test_where_found_in_ext_src(project):
-    _make_addon(config.ext_src_rel_path / "some_repo" / "my_addon")
+    make_fake_addon(config.ext_src_rel_path / "some_repo" / "my_addon")
     result = project.invoke(addon.where, "my_addon")
     assert result.exit_code == 0
     assert str(config.ext_src_rel_path / "some_repo" / "my_addon") in result.output
 
 
 def test_where_found_in_odoo_addons(project):
-    _make_addon(config.odoo_src_rel_path / "addons" / "my_addon")
+    make_fake_addon(config.odoo_src_rel_path / "addons" / "my_addon")
     result = project.invoke(addon.where, "my_addon")
     assert result.exit_code == 0
     assert str(config.odoo_src_rel_path / "addons" / "my_addon") in result.output
 
 
 def test_where_found_in_odoo_base_addons(project):
-    _make_addon(config.odoo_src_rel_path / "odoo" / "addons" / "my_addon")
+    make_fake_addon(config.odoo_src_rel_path / "odoo" / "addons" / "my_addon")
     result = project.invoke(addon.where, "my_addon")
     assert result.exit_code == 0
     assert (
@@ -51,8 +44,8 @@ def test_where_not_found(project):
 
 
 def test_where_multiple_occurrences(project):
-    _make_addon(config.local_src_rel_path / "my_addon")
-    _make_addon(config.odoo_src_rel_path / "addons" / "my_addon")
+    make_fake_addon(config.local_src_rel_path / "my_addon")
+    make_fake_addon(config.odoo_src_rel_path / "addons" / "my_addon")
     result = project.invoke(addon.where, "my_addon")
     assert result.exit_code == 0
     lines = result.output.strip().splitlines()
@@ -62,7 +55,9 @@ def test_where_multiple_occurrences(project):
 
 
 def test_where_openerp_manifest(project):
-    _make_addon(config.local_src_rel_path / "old_addon", manifest="__openerp__.py")
+    make_fake_addon(
+        config.local_src_rel_path / "old_addon", manifest_filename="__openerp__.py"
+    )
     result = project.invoke(addon.where, "old_addon")
     assert result.exit_code == 0
     assert str(config.local_src_rel_path / "old_addon") in result.output

--- a/uv.lock
+++ b/uv.lock
@@ -3,6 +3,15 @@ revision = 3
 requires-python = ">=3.10"
 
 [[package]]
+name = "annotated-doc"
+version = "0.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4", size = 7288, upload-time = "2025-11-10T22:07:42.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320", size = 5303, upload-time = "2025-11-10T22:07:40.673Z" },
+]
+
+[[package]]
 name = "annotated-types"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -517,6 +526,44 @@ wheels = [
 ]
 
 [[package]]
+name = "linkify-it-py"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "uc-micro-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2e/c9/06ea13676ef354f0af6169587ae292d3e2406e212876a413bf9eece4eb23/linkify_it_py-2.1.0.tar.gz", hash = "sha256:43360231720999c10e9328dc3691160e27a718e280673d444c38d7d3aaa3b98b", size = 29158, upload-time = "2026-03-01T07:48:47.683Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b4/de/88b3be5c31b22333b3ca2f6ff1de4e863d8fe45aaea7485f591970ec1d3e/linkify_it_py-2.1.0-py3-none-any.whl", hash = "sha256:0d252c1594ecba2ecedc444053db5d3a9b7ec1b0dd929c8f1d74dce89f86c05e", size = 19878, upload-time = "2026-03-01T07:48:46.098Z" },
+]
+
+[[package]]
+name = "manifestoo"
+version = "1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "manifestoo-core" },
+    { name = "textual" },
+    { name = "typer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b2/1d/0937b4eaec56f393c2bfbfed013b7fd78d7e735bb5ef291a0d864f989545/manifestoo-1.1.tar.gz", hash = "sha256:5837e4b56f23c61ddb96bd011f6a7acff3e5e95910b8baa20b9f9a9189e1695e", size = 24307, upload-time = "2025-09-23T08:24:43.131Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/68/1a/096647b826caad99e2c1ab7d3e7c8ffc78afa893d8fa79324a22f7f2686a/manifestoo-1.1-py3-none-any.whl", hash = "sha256:27d35641247f4220246273a7554b43306dee668f8b14fefbce37a980ca8b3604", size = 19321, upload-time = "2025-09-23T08:24:41.609Z" },
+]
+
+[[package]]
+name = "manifestoo-core"
+version = "1.15.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8f/a7/9d9bf3797b602466dbb0b247201dc1f6b6e31e5d3e38e93923e033aee458/manifestoo_core-1.15.4.tar.gz", hash = "sha256:c14c7b6212ccbfffe7a9eb096e06082d58832581de181a69d3936a01e7740f1e", size = 42343, upload-time = "2026-07-05T15:05:07.785Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/66/ff/e2e320c4f6b141a18668714746cc36e63c48eb0c51e36125763c586dddd2/manifestoo_core-1.15.4-py3-none-any.whl", hash = "sha256:334dfc27bbb2df50b31afe1d4153cca42ba3074b2170d3baeffad2cc20ea360d", size = 66013, upload-time = "2026-07-05T15:05:06.314Z" },
+]
+
+[[package]]
 name = "markdown-it-py"
 version = "4.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -526,6 +573,11 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321, upload-time = "2025-08-11T12:57:51.923Z" },
+]
+
+[package.optional-dependencies]
+linkify = [
+    { name = "linkify-it-py" },
 ]
 
 [[package]]
@@ -614,6 +666,18 @@ wheels = [
 ]
 
 [[package]]
+name = "mdit-py-plugins"
+version = "0.6.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/59/fc/f8d0863f8862f25602c0404d75568e89fb6b4109804645e5cdfb1be5cf56/mdit_py_plugins-0.6.1.tar.gz", hash = "sha256:a2bca0f039f39dbd35fb74ae1b5f998608c437463371f0ff7f49a19a17a114d0", size = 56114, upload-time = "2026-05-13T09:03:38.91Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a5/69/6da5581c6a7fede7dc261bf4e67d6adca4196f176b43288b55b3db395b6e/mdit_py_plugins-0.6.1-py3-none-any.whl", hash = "sha256:214c82fb2ac524472ab6a5bcab1de80f73b50443e187f401bfd77efbc7c6481d", size = 66663, upload-time = "2026-05-13T09:03:37.76Z" },
+]
+
+[[package]]
 name = "mdurl"
 version = "0.1.2"
 source = { registry = "https://pypi.org/simple" }
@@ -643,6 +707,7 @@ dependencies = [
     { name = "git-autoshare" },
     { name = "gitpython" },
     { name = "jinja2" },
+    { name = "manifestoo" },
     { name = "packaging" },
     { name = "passlib" },
     { name = "pre-commit" },
@@ -673,6 +738,7 @@ requires-dist = [
     { name = "git-autoshare" },
     { name = "gitpython" },
     { name = "jinja2" },
+    { name = "manifestoo" },
     { name = "packaging" },
     { name = "passlib" },
     { name = "pre-commit" },
@@ -1204,6 +1270,15 @@ wheels = [
 ]
 
 [[package]]
+name = "shellingham"
+version = "1.5.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
+]
+
+[[package]]
 name = "six"
 version = "1.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1228,6 +1303,23 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ab/e2/e9a00f0ccb71718418230718b3d900e71a5d16e701a3dae079a21e9cd8f8/text-unidecode-1.3.tar.gz", hash = "sha256:bad6603bb14d279193107714b288be206cac565dfa49aa5b105294dd5c4aab93", size = 76885, upload-time = "2019-08-30T21:36:45.405Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a6/a5/c0b6468d3824fe3fde30dbb5e1f687b291608f9473681bbf7dabbf5a87d7/text_unidecode-1.3-py2.py3-none-any.whl", hash = "sha256:1311f10e8b895935241623731c2ba64f4c455287888b18189350b67134a822e8", size = 78154, upload-time = "2019-08-30T21:37:03.543Z" },
+]
+
+[[package]]
+name = "textual"
+version = "8.2.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py", extra = ["linkify"] },
+    { name = "mdit-py-plugins" },
+    { name = "platformdirs" },
+    { name = "pygments" },
+    { name = "rich" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/00/21/39a76b01bd5eea82a04baaca7580e105d8c59450df03998345bb2cfb307b/textual-8.2.8.tar.gz", hash = "sha256:3f106a9fbc73e39dd266c9712432087de78a6d644084c7c241d6a25c3169115b", size = 1860502, upload-time = "2026-06-30T06:51:24.495Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/be/35261223d9416a0751cdff1c7b4a6f881387218a12d439fe22fefebc8c04/textual-8.2.8-py3-none-any.whl", hash = "sha256:267375fd402dc8d981457212efa71f0e3365fd17bba144ba9bb3ed7563cb374a", size = 731418, upload-time = "2026-06-30T06:51:26.364Z" },
 ]
 
 [[package]]
@@ -1342,6 +1434,21 @@ wheels = [
 ]
 
 [[package]]
+name = "typer"
+version = "0.26.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "rich" },
+    { name = "shellingham" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7c/f7/68adc395201b20b872d68e975386832e8005ffeacedd43a1d837a32815be/typer-0.26.8.tar.gz", hash = "sha256:c244a6bd558886fe3f8780efb6bdd28bb9aff005a94eedebaa5cb32926fe2f7e", size = 202097, upload-time = "2026-06-26T09:22:45.705Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/80/87/b9fd69c92c6102a066e1b86a35243f53e70bd4c709f2a26d9f4fee4f4dc0/typer-0.26.8-py3-none-any.whl", hash = "sha256:3512ca79ac5c11113414b36e80281b872884477722440691c89d1112e321a49c", size = 122564, upload-time = "2026-06-26T09:22:44.72Z" },
+]
+
+[[package]]
 name = "typing-extensions"
 version = "4.15.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1369,6 +1476,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/5e/a7/c202b344c5ca7daf398f3b8a477eeb205cf3b6f32e7ec3a6bac0629ca975/tzdata-2025.3.tar.gz", hash = "sha256:de39c2ca5dc7b0344f2eba86f49d614019d29f060fc4ebc8a417896a620b56a7", size = 196772, upload-time = "2025-12-13T17:45:35.667Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/b0/003792df09decd6849a5e39c28b513c06e84436a54440380862b5aeff25d/tzdata-2025.3-py2.py3-none-any.whl", hash = "sha256:06a47e5700f3081aab02b2e513160914ff0694bce9947d6b76ebd6bf57cfc5d1", size = 348521, upload-time = "2025-12-13T17:45:33.889Z" },
+]
+
+[[package]]
+name = "uc-micro-py"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/78/67/9a363818028526e2d4579334460df777115bdec1bb77c08f9db88f6389f2/uc_micro_py-2.0.0.tar.gz", hash = "sha256:c53691e495c8db60e16ffc4861a35469b0ba0821fe409a8a7a0a71864d33a811", size = 6611, upload-time = "2026-03-01T06:31:27.526Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/61/73/d21edf5b204d1467e06500080a50f79d49ef2b997c79123a536d4a17d97c/uc_micro_py-2.0.0-py3-none-any.whl", hash = "sha256:3603a3859af53e5a39bc7677713c78ea6589ff188d70f4fee165db88e22b242c", size = 6383, upload-time = "2026-03-01T06:31:26.257Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Integrate [manifestoo](https://github.com/acsone/manifestoo) as a dependency, wrapping it with the project's addons paths and configuration so it can be called without passing them explicitly.

New commands:

- `otools-addon list`: list the project's local addons
- `otools-addon depends`: list the dependencies of the given addons, or of the whole local-src when no addon is given. For example, to list all the addons used by the project: `otools-addon depends --transitive --include-selected`
- `otools-addon codepends`: list the addons depending on the given addons

Missing addons fail the command by default (like the upstream manifestoo CLI); `--ignore-missing` turns them into a warning on stderr, and `--quiet` silences the warning. All commands support `--separator` to join the output on one line.