### PR TITLE
[FIX] proj: read project_id from the manifest, not .proj.cfg

### DIFF
--- a/odoo_tools/cli/project.py
+++ b/odoo_tools/cli/project.py
@@ -18,24 +18,11 @@ from ..utils.misc import (
     get_docker_image_commit_hashes,
     get_template_path,
 )
-from ..utils.path import build_path, root_path
+from ..utils.path import build_path
 from ..utils.proj import (
     generate_odoo_config_file,
     setup_venv,
 )
-
-_README_PROJECT_ID_RE = re.compile(r"Our internal id for this project is: (\d+)")
-
-
-def _read_project_id_from_readme() -> str | None:
-    """Extract the project ID from README.md at the project root, if present."""
-    readme = root_path() / "README.md"
-    try:
-        content = readme.read_text()
-    except FileNotFoundError:
-        return None
-    match = _README_PROJECT_ID_RE.search(content)
-    return match.group(1) if match else None
 
 
 # TODO: proj_tmpl_ver=2 is deprecated
@@ -144,9 +131,6 @@ def get_init_template_files():
             "source": f".proj.v{get_proj_tmpl_ver() or '1'}.cfg",
             "destination": build_path(f"./{PROJ_CFG_FILE}"),
             "check": lambda source_path, dest_path: not dest_path.exists(),
-            "variables_getter": lambda opts: {
-                "project_id": _read_project_id_from_readme()
-            },
         },
         {
             "source": "docker-compose.override.tmpl.yml",

--- a/odoo_tools/templates/.proj.v1.cfg
+++ b/odoo_tools/templates/.proj.v1.cfg
@@ -13,7 +13,3 @@ marabunta_mig_file_rel_path = odoo/migration.yml
 # Minimum required odoo-tools version for this project.
 # Leave unset to allow any installed version.
 # otools_min_version = 0.14.0
-{% if project_id %}
-# Internal compan project ID (used by otools-submodule to configure remotes)
-project_id = {{ project_id }}
-{% endif %}

--- a/odoo_tools/templates/.proj.v2.cfg
+++ b/odoo_tools/templates/.proj.v2.cfg
@@ -15,7 +15,3 @@ marabunta_mig_file_rel_path = migration.yml
 # Minimum required odoo-tools version for this project.
 # Leave unset to allow any installed version.
 # otools_min_version = 0.14.0
-{% if project_id %}
-# Internal company project ID (used by otools-submodule to configure remotes)
-project_id = {{ project_id }}
-{% endif %}

--- a/odoo_tools/utils/config.py
+++ b/odoo_tools/utils/config.py
@@ -110,15 +110,6 @@ class ProjectConfig(BaseModel):
     marabunta_mig_file_rel_path: OptionalPath = None
     """The path to the Marabunta migration file."""
 
-    project_id: Annotated[str | None, BeforeValidator(falsy_to_none)] = None
-    """The internal company's project ID.
-
-    Set automatically by ``otools-project init`` from the README when the line
-    ``Our internal id for this project is: <id>`` is present.  Used by
-    ``otools-submodule`` to configure targeted fetch refspecs for OCA and
-    company remotes.
-    """
-
     otools_min_version: Annotated[str | None, BeforeValidator(falsy_to_none)] = None
     """The minimum required version of odoo-tools to operate on this project.
 

--- a/odoo_tools/utils/gh.py
+++ b/odoo_tools/utils/gh.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 from . import git, ui
 from .os_exec import run
-from .proj import get_project_manifest_key
+from .proj import get_project_id
 
 RE_GH_REMOTE_URL = re.compile(
     r"^(?:https?://github\.com/|git@github\.com:)"
@@ -99,7 +99,7 @@ def get_target_branch(target_branch=None):
     current_branch = get_current_rebase_branch()
     if not current_branch:
         current_branch = git.get_current_branch()
-    project_id = get_project_manifest_key("project_id")
+    project_id = get_project_id()
     if not target_branch:
         commit = run("git rev-parse HEAD")[:8]
         target_branch = f"merge-branch-{project_id}-{current_branch}-{commit}"

--- a/odoo_tools/utils/git.py
+++ b/odoo_tools/utils/git.py
@@ -286,7 +286,7 @@ def submodule_update(path: str | PathLike):
     company_remote = proj_config.company_git_remote
     if submodule:
         ui.echo(f"Updating submodule {submodule.path}")
-        project_id = get_project_id()
+        project_id = get_project_id(raise_if_missing=False)
         base_branch = submodule.branch or base_branch
         __, autoshare_repo = find_autoshare_repository([submodule.url])
         if autoshare_repo:

--- a/odoo_tools/utils/pending_merge.py
+++ b/odoo_tools/utils/pending_merge.py
@@ -20,7 +20,7 @@ from ..utils.misc import SmartDict, get_docker_image_commit_hashes
 from . import gh, git, ui
 from .config import config
 from .path import build_path, cd
-from .proj import get_project_manifest_key
+from .proj import get_project_id, get_project_manifest_key
 from .yaml import (
     append_seq_item_with_comments,
     remove_seq_item_with_comments,
@@ -238,9 +238,7 @@ class Repo:
         remote_upstream_url = self.ssh_url(upstream)
         remote_company_url = self.ssh_url()
         odoo_version = get_project_manifest_key("odoo_version")
-        default_target = "merge-branch-{}-master".format(
-            get_project_manifest_key("project_id")
-        )
+        default_target = f"merge-branch-{get_project_id()}-master"
         remotes = CommentedMap()
         remotes.insert(0, upstream, remote_upstream_url)
 
@@ -720,7 +718,7 @@ def remove_pending(entity_url, aggregate=True):
 
 
 def make_merge_branch_name(version):
-    project_id = get_project_manifest_key("project_id")
+    project_id = get_project_id()
     branch_name = f"merge-branch-{project_id}-{version}"
     return branch_name
 

--- a/odoo_tools/utils/proj.py
+++ b/odoo_tools/utils/proj.py
@@ -5,6 +5,7 @@ import subprocess
 import venv
 from functools import cache
 
+from ..exceptions import ProjectConfigException
 from . import addon, ui
 from .config import config
 from .misc import get_template_path
@@ -34,14 +35,12 @@ def get_odoo_serie():
     return get_odoo_version().split(".")[0]
 
 
-def get_project_id() -> str | None:
-    """Return the project ID from the project config (.proj.cfg), or None.
-
-    The value is stored in .proj.cfg as ``project_id`` and written there
-    automatically by ``otools-project init`` when the README contains the
-    line ``Our internal id for this project is: <id>``.
-    """
-    return config.project_id
+def get_project_id(raise_if_missing=True) -> str | None:
+    """Return the internal company project ID from the project manifest."""
+    project_id = get_project_manifest().get("project_id")
+    if not project_id and raise_if_missing:
+        raise ProjectConfigException("project_id not found in the project manifest")
+    return str(project_id) if project_id else None
 
 
 def get_current_version():

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -55,25 +55,6 @@ def test_init(project, version):
     os.environ["GIT_AUTOSHARE_CONFIG_DIR"] = str(autoshare_config_dir)
 
 
-@pytest.mark.project_setup(
-    proj_tmpl_ver=1,
-    extra_files={
-        "README.md": "# Proj\n\n**Our internal id for this project is: 1289.**\n",
-    },
-)
-def test_init_writes_project_id_from_readme(project):
-    Path(".proj.cfg").unlink()
-    config._reload()
-    with mock.patch.dict(os.environ, {"PROJ_TMPL_VER": "1"}, clear=True):
-        result = project.invoke(init, catch_exceptions=False)
-    assert result.exit_code == 0
-    content = Path(".proj.cfg").read_text()
-    assert "project_id = 1289" in content
-    # Reload and verify config picks up the value
-    config._reload()
-    assert config.project_id == "1289"
-
-
 @pytest.mark.project_setup(proj_tmpl_ver=1)
 def test_init_proj_conf_already_existing(project):
     orig_content = get_fixture("expected.proj.v1.cfg")

--- a/tests/test_utils_git.py
+++ b/tests/test_utils_git.py
@@ -8,6 +8,7 @@ from unittest import mock
 import git
 import pytest
 
+from odoo_tools.exceptions import ProjectConfigException
 from odoo_tools.utils import git as git_utils
 from odoo_tools.utils import proj as proj_utils
 
@@ -27,20 +28,21 @@ def _make_autoshare_repo(repo_dir):
 
 
 @pytest.mark.project_setup(
-    manifest=dict(odoo_version="18.0"),
+    manifest=dict(odoo_version="18.0", project_id="1289"),
     proj_version="18.0.1.0.0",
-    proj_cfg={"project_id": "1289"},
 )
-def test_get_project_id_from_cfg(project):
+def test_get_project_id_from_manifest(project):
     assert proj_utils.get_project_id() == "1289"
 
 
 @pytest.mark.project_setup(
-    manifest=dict(odoo_version="18.0"),
+    manifest=dict(odoo_version="18.0", project_id=None),
     proj_version="18.0.1.0.0",
 )
-def test_get_project_id_returns_none_when_not_set(project):
-    assert proj_utils.get_project_id() is None
+def test_get_project_id_not_set(project):
+    assert proj_utils.get_project_id(raise_if_missing=False) is None
+    with pytest.raises(ProjectConfigException):
+        proj_utils.get_project_id()
 
 
 # ── _repo_name_from_url ───────────────────────────────────────────────────────
@@ -382,9 +384,8 @@ def test_pin_submodule_commit_not_in_store():
 
 
 @pytest.mark.project_setup(
-    manifest=dict(odoo_version="18.0"),
+    manifest=dict(odoo_version="18.0", project_id="1289"),
     proj_version="18.0.1.0.0",
-    proj_cfg={"project_id": "1289"},
     extra_files={
         ".gitmodules": Path(get_fixture_path("fake-gitmodules")).read_text(),
     },
@@ -435,9 +436,8 @@ def test_submodule_update_populates_autoshare_remotes(project, tmp_path):
 
 
 @pytest.mark.project_setup(
-    manifest=dict(odoo_version="18.0"),
+    manifest=dict(odoo_version="18.0", project_id="1289"),
     proj_version="18.0.1.0.0",
-    proj_cfg={"project_id": "1289"},
     extra_files={
         ".gitmodules": Path(get_fixture_path("fake-gitmodules")).read_text(),
     },


### PR DESCRIPTION
The project manifest (.cookiecutter.context.yml) has always carried project_id, but 4fa250e overlooked it and added a duplicate: project init scraped the ID from the README and wrote it into .proj.cfg.

Make the manifest the single source of truth:

- get_project_id() now reads it from the manifest.
- Remove the README parsing, the .proj.cfg template blocks and the ProjectConfig.project_id field. Leftover project_id keys in existing .proj.cfg files are harmless: pydantic ignores unknown keys.
- Use get_project_id() everywhere instead of raw manifest lookups.