### PR TITLE
[IMP] pending clean: ask before re-aggregating touched submodules

### DIFF
--- a/odoo_tools/cli/pending.py
+++ b/odoo_tools/cli/pending.py
@@ -9,6 +9,7 @@ import click
 from rich.console import Console
 from rich.live import Live
 from rich.markup import escape
+from rich.prompt import Confirm
 from rich.spinner import Spinner
 from rich.table import Table
 
@@ -137,10 +138,11 @@ def show_pending(repo_paths=(), check=True, as_json=False):
     "--aggregate/--no-aggregate",
     "aggregate",
     is_flag=True,
-    default=True,
-    help="Run git aggregate (and push) on each touched repo after purging",
+    default=None,
+    help="Run git aggregate (and push) on each touched repo after purging. "
+    "If not set, you will be prompted for each touched repo.",
 )
-def clean_pending(repo_paths=(), aggregate=True):
+def clean_pending(repo_paths=(), aggregate=None):
     """Remove merged pull requests from pending-merge files."""
     repos = _resolve_repos(repo_paths)
     all_prs = [pr for repo in repos for pr in repo._iter_pending_pull_requests()]
@@ -207,7 +209,18 @@ def clean_pending(repo_paths=(), aggregate=True):
     for repo in touched_repos:
         if not repo.has_any_pr_left():
             repo._handle_empty_merges_file(delete_file=True)
-        elif aggregate:
+            continue
+        # Re-aggregating performs an upgrade of the submodule, potentially
+        # pulling breaking changes from the remaining pending merges, so
+        # unless the choice was made explicit via the flag, ask first.
+        do_aggregate = aggregate
+        if do_aggregate is None:
+            do_aggregate = Confirm.ask(
+                f"Re-aggregate {repo.path}? This may pull new changes "
+                "from the remaining pending merges",
+                default=True,
+            )
+        if do_aggregate:
             repo.run_aggregate()
             repo.push_to_remote()
 

--- a/tests/test_utils_pending_merge.py
+++ b/tests/test_utils_pending_merge.py
@@ -829,6 +829,72 @@ def test_repo_push_to_remote(project):
     )
 
 
+def _mock_clean_github_responses(rsps, merged_prs=(773,), open_prs=(774, 663, 759)):
+    """Register GitHub API responses for the PRs of the default merges file."""
+    for pull_id in merged_prs:
+        rsps.add(
+            responses.GET,
+            f"https://api.github.com/repos/OCA/edi/pulls/{pull_id}",
+            json={"state": "closed", "merged": True, "number": pull_id},
+            status=200,
+        )
+    for pull_id in open_prs:
+        rsps.add(
+            responses.GET,
+            f"https://api.github.com/repos/OCA/edi/pulls/{pull_id}",
+            json={"state": "open", "merged": False, "number": pull_id},
+            status=200,
+        )
+
+
+@pytest.mark.parametrize(("answer", "aggregated"), [("y", True), ("n", False)])
+def test_cli_clean_prompts_for_aggregate(project, answer, aggregated):
+    """Without an explicit --aggregate/--no-aggregate flag, `otools-pending
+    clean` asks before re-aggregating each touched submodule."""
+    mock_pending_merge_repo_paths("edi")
+    repo = Repo("edi", path_check=False)
+    with responses.RequestsMock() as rsps:
+        _mock_clean_github_responses(rsps)
+        with (
+            mock.patch.object(pm_utils.Repo, "run_aggregate") as run_aggregate,
+            mock.patch.object(pm_utils.Repo, "push_to_remote") as push_to_remote,
+        ):
+            result = project.invoke(
+                pending.clean_pending,
+                catch_exceptions=False,
+                input=answer,
+            )
+    assert result.exit_code == 0
+    assert "Re-aggregate" in result.output
+    # The merged PR is removed regardless of the aggregation answer
+    assert "OCA refs/pull/773/head" not in repo.merges_config()["merges"]
+    assert run_aggregate.called is aggregated
+    assert push_to_remote.called is aggregated
+
+
+@pytest.mark.parametrize(
+    ("flag", "aggregated"), [("--aggregate", True), ("--no-aggregate", False)]
+)
+def test_cli_clean_explicit_aggregate_flag_skips_prompt(project, flag, aggregated):
+    """An explicit --aggregate/--no-aggregate flag is honored without asking."""
+    mock_pending_merge_repo_paths("edi")
+    with responses.RequestsMock() as rsps:
+        _mock_clean_github_responses(rsps)
+        with (
+            mock.patch.object(pm_utils.Repo, "run_aggregate") as run_aggregate,
+            mock.patch.object(pm_utils.Repo, "push_to_remote") as push_to_remote,
+        ):
+            result = project.invoke(
+                pending.clean_pending,
+                [flag],
+                catch_exceptions=False,
+            )
+    assert result.exit_code == 0
+    assert "Re-aggregate" not in result.output
+    assert run_aggregate.called is aggregated
+    assert push_to_remote.called is aggregated
+
+
 def test_iter_pending_pull_requests(project):
     name = "edi"
     mock_pending_merge_repo_paths(


### PR DESCRIPTION
Re-aggregating performs an upgrade of the submodule, potentially pulling breaking changes from the remaining pending merges.

The `--aggregate` flag on `otools-pending clean` now defaults to `None` (tri-state): when not explicitly set, the user is prompted for each touched repo instead of silently aggregating. Passing `--aggregate` or `--no-aggregate` keeps the previous non-interactive behavior.

Closes #242