### PR TITLE
[FIX] submodule: don't re-handle deleted pending-merges file on upgrade

### DIFF
--- a/odoo_tools/cli/submodule.py
+++ b/odoo_tools/cli/submodule.py
@@ -168,8 +168,6 @@ def upgrade(submodule_path, force_branch):
                 ui.echo(f"Purging merged PRs for {submodule.path}")
                 for pr in repo.purge_merged_prs():
                     ui.echo(f"  removed {pr.shortcut}")
-                if not repo.has_any_pr_left():
-                    repo._handle_empty_merges_file(delete_file=True)
             if repo.has_pending_merges():
                 ui.echo(f"Rebuilding consolidation branch for {submodule.path}")
                 repo.rebuild_consolidation_branch(push=True)

--- a/odoo_tools/utils/pending_merge.py
+++ b/odoo_tools/utils/pending_merge.py
@@ -627,7 +627,7 @@ class Repo:
         if delete_file or ui.ask_confirmation(
             f"Delete pending merge file {self.abs_merges_path}?"
         ):
-            self.abs_merges_path.unlink()
+            self.abs_merges_path.unlink(missing_ok=True)
 
     def push_to_remote(self, target_branch=None):
         """Push the aggregated HEAD to the company remote as ``target_branch``.

--- a/tests/test_submodule.py
+++ b/tests/test_submodule.py
@@ -354,6 +354,52 @@ def test_upgrade_with_pending_merges(project):
         ".gitmodules": Path(get_fixture_path("fake-gitmodules")).read_text(),
     },
 )
+def test_upgrade_pending_merges_all_purged(project):
+    # Regression test for #252: when purging removes the last pending PR,
+    # purge_merged_prs() already deletes the pending-merges file. The upgrade
+    # command must NOT call _handle_empty_merges_file() again, otherwise it
+    # reads the now-deleted file and crashes with FileNotFoundError.
+    # True the first time (enter purge branch), False afterwards because
+    # purge_merged_prs() deleted the now-empty pending-merges file.
+    pending_merges = iter([True])
+
+    def fake_has_pending_merges(self):
+        return next(pending_merges, False)
+
+    with (
+        mock.patch.object(
+            submodule.pm_utils.Repo,
+            "has_pending_merges",
+            autospec=True,
+            side_effect=fake_has_pending_merges,
+        ),
+        mock.patch.object(
+            submodule.pm_utils.Repo, "purge_merged_prs", return_value=[]
+        ) as mock_purge,
+        mock.patch.object(
+            submodule.pm_utils.Repo, "_handle_empty_merges_file"
+        ) as mock_handle,
+        mock.patch.object(submodule.git, "submodule_update"),
+        mock.patch.object(submodule.git, "submodule_upgrade"),
+    ):
+        result = project.invoke(
+            submodule.upgrade,
+            ["odoo/external-src/account-closing"],
+            catch_exceptions=False,
+        )
+    assert result.exit_code == 0
+    mock_purge.assert_called_once_with()
+    # The caller must not re-handle the empty file; purge_merged_prs() owns it.
+    mock_handle.assert_not_called()
+
+
+@pytest.mark.project_setup(
+    manifest=dict(odoo_version="16.0"),
+    proj_version="16.0.1.2.3",
+    extra_files={
+        ".gitmodules": Path(get_fixture_path("fake-gitmodules")).read_text(),
+    },
+)
 def test_upgrade_force_branch(project):
     commit_before = "aaa111"
     commit_after = "bbb222"

--- a/tests/test_utils_pending_merge.py
+++ b/tests/test_utils_pending_merge.py
@@ -461,6 +461,25 @@ def test_remove_pending_last_pr():
 
 
 @pytest.mark.project_setup(manifest=dict(odoo_version="16.0"))
+def test_handle_empty_merges_file_unlink_is_idempotent(project):
+    """Deleting the merges file stays safe if it is already gone (#252)."""
+    name = "edi"
+    mock_pending_merge_repo_paths(name, pending=False)  # no merges file on disk
+    repo = Repo(name, path_check=False)
+    assert not repo.abs_merges_path.exists()
+    with (
+        mock.patch.object(
+            Repo, "merges_config", return_value={"remotes": {"OCA": "url"}}
+        ),
+        # "9" == "no update", so no remote/checkout git calls are triggered.
+        mock.patch.object(pm_utils.ui, "ask_question", return_value="9"),
+        mock.patch.object(pm_utils.ui, "ask_confirmation", return_value=True),
+    ):
+        # The unlink must not raise FileNotFoundError for the missing file.
+        repo._handle_empty_merges_file(delete_file=False)
+
+
+@pytest.mark.project_setup(manifest=dict(odoo_version="16.0"))
 def __test_add_pending_commit_from_scratch(project):
     name = "edi"
     mock_pending_merge_repo_paths(name, pending=False)


### PR DESCRIPTION
## Problem

`otools-submodule upgrade` crashes with `FileNotFoundError` after purging a submodule's last pending PR.

When a submodule has only one pending merge request that gets merged upstream, the upgrade command correctly removes it and deletes the now-empty pending-merges file — then immediately crashes trying to read that deleted file, aborting the entire upgrade run.

## Root cause

`_handle_empty_merges_file(delete_file=True)` was invoked **twice**:

1. First inside `Repo.purge_merged_prs()`, which deletes the file.
2. Again by the caller in `cli/submodule.py`.

On the second invocation, `merges_config()` calls `read_text()` on the already-deleted path:

```
FileNotFoundError: [Errno 2] No such file or directory: '.../pending-merges.d/<repo>.yml'
```

## Fix

- Remove the redundant cleanup block from the `upgrade` command — `purge_merged_prs()` already owns the empty-file case.
- As a safeguard, make the file deletion idempotent with `unlink(missing_ok=True)`.

## Tests

- `test_upgrade_pending_merges_all_purged` — regression test reproducing the crash at the CLI level (fails before the fix, passes after).
- `test_handle_empty_merges_file_unlink_is_idempotent` — unit test covering the idempotent unlink.

Full suite: 382 passed, 2 xfailed.

Closes #252
