### PR TITLE
[IMP] pending clean: ask once whether to re-aggregate

### DIFF
--- a/odoo_tools/cli/pending.py
+++ b/odoo_tools/cli/pending.py
@@ -140,7 +140,7 @@ def show_pending(repo_paths=(), check=True, as_json=False):
     is_flag=True,
     default=None,
     help="Run git aggregate (and push) on each touched repo after purging. "
-    "If not set, you will be prompted for each touched repo.",
+    "If not set, you will be prompted once.",
 )
 def clean_pending(repo_paths=(), aggregate=None):
     """Remove merged pull requests from pending-merge files."""
@@ -198,31 +198,35 @@ def clean_pending(repo_paths=(), aggregate=None):
                 live.update(build_grid())
                 continue
             if pr.merged:
-                if pr.is_patch:
-                    pr._repo.remove_pending_pull_from_patches(pr.owner, pr.pr)
-                else:
-                    pr._repo.remove_pending_pull(pr.owner, pr.pr)
+                pr.remove_from_merges_file()
                 touched_repos.add(pr._repo)
                 removed.add(id(pr))
             live.update(build_grid())
-    # Per-repo post-processing: clean up an empty merges file or re-aggregate.
-    for repo in touched_repos:
-        if not repo.has_any_pr_left():
+    # Dispose of the merges files left without any pending merge, and keep the
+    # rest for re-aggregation.
+    to_aggregate = []
+    for repo in sorted(touched_repos, key=lambda repo: repo.name):
+        if repo.has_any_pr_left():
+            to_aggregate.append(repo)
+        else:
             repo._handle_empty_merges_file(delete_file=True)
-            continue
-        # Re-aggregating performs an upgrade of the submodule, potentially
-        # pulling breaking changes from the remaining pending merges, so
-        # unless the choice was made explicit via the flag, ask first.
-        do_aggregate = aggregate
-        if do_aggregate is None:
-            do_aggregate = Confirm.ask(
-                f"Re-aggregate {repo.path}? This may pull new changes "
-                "from the remaining pending merges",
-                default=True,
-            )
-        if do_aggregate:
-            repo.run_aggregate()
-            repo.push_to_remote()
+    if not to_aggregate:
+        return
+    # Re-aggregating performs an upgrade of the submodules, potentially pulling
+    # breaking changes from the remaining pending merges, so unless the choice
+    # was made explicit via the flag, ask first -- once for all of them.
+    if aggregate is None:
+        names = ", ".join(repo.name for repo in to_aggregate)
+        aggregate = Confirm.ask(
+            f"Re-aggregate {names}? This may pull new changes "
+            "from the remaining pending merges",
+            default=True,
+        )
+    if not aggregate:
+        return
+    for repo in to_aggregate:
+        repo.run_aggregate()
+        repo.push_to_remote()
 
 
 # TODO: add tests

--- a/odoo_tools/utils/pending_merge.py
+++ b/odoo_tools/utils/pending_merge.py
@@ -86,6 +86,13 @@ class PendingPR:
             "url": self.url,
         }
 
+    def remove_from_merges_file(self) -> None:
+        """Drop this pull request from its repo's pending-merges file."""
+        if self.is_patch:
+            self._repo.remove_pending_pull_from_patches(self.owner, self.pr)
+        else:
+            self._repo.remove_pending_pull(self.owner, self.pr)
+
     def enrich_with_github(self) -> None:
         """Fetch the PR's GitHub state and update this instance in place.
 
@@ -563,10 +570,7 @@ class Repo:
                 continue
             if not pr.merged:
                 continue
-            if pr.is_patch:
-                self.remove_pending_pull_from_patches(pr.owner, pr.pr)
-            else:
-                self.remove_pending_pull(pr.owner, pr.pr)
+            pr.remove_from_merges_file()
             yield pr
         if not self.has_any_pr_left():
             self._handle_empty_merges_file(delete_file=True)

--- a/tests/test_utils_pending_merge.py
+++ b/tests/test_utils_pending_merge.py
@@ -848,19 +848,21 @@ def test_repo_push_to_remote(project):
     )
 
 
-def _mock_clean_github_responses(rsps, merged_prs=(773,), open_prs=(774, 663, 759)):
+def _mock_clean_github_responses(
+    rsps, repo_name="edi", merged_prs=(773,), open_prs=(774, 663, 759)
+):
     """Register GitHub API responses for the PRs of the default merges file."""
     for pull_id in merged_prs:
         rsps.add(
             responses.GET,
-            f"https://api.github.com/repos/OCA/edi/pulls/{pull_id}",
+            f"https://api.github.com/repos/OCA/{repo_name}/pulls/{pull_id}",
             json={"state": "closed", "merged": True, "number": pull_id},
             status=200,
         )
     for pull_id in open_prs:
         rsps.add(
             responses.GET,
-            f"https://api.github.com/repos/OCA/edi/pulls/{pull_id}",
+            f"https://api.github.com/repos/OCA/{repo_name}/pulls/{pull_id}",
             json={"state": "open", "merged": False, "number": pull_id},
             status=200,
         )
@@ -889,6 +891,30 @@ def test_cli_clean_prompts_for_aggregate(project, answer, aggregated):
     assert "OCA refs/pull/773/head" not in repo.merges_config()["merges"]
     assert run_aggregate.called is aggregated
     assert push_to_remote.called is aggregated
+
+
+def test_cli_clean_prompts_for_aggregate_once_for_all_repos(project):
+    """The re-aggregation question is asked once, listing every touched
+    submodule, rather than once per submodule."""
+    mock_pending_merge_repo_paths("edi")
+    mock_pending_merge_repo_paths("web")
+    with responses.RequestsMock() as rsps:
+        _mock_clean_github_responses(rsps, repo_name="edi")
+        _mock_clean_github_responses(rsps, repo_name="web")
+        with (
+            mock.patch.object(pm_utils.Repo, "run_aggregate") as run_aggregate,
+            mock.patch.object(pm_utils.Repo, "push_to_remote") as push_to_remote,
+        ):
+            result = project.invoke(
+                pending.clean_pending,
+                catch_exceptions=False,
+                input="y",
+            )
+    assert result.exit_code == 0
+    assert result.output.count("Re-aggregate") == 1
+    assert "Re-aggregate edi, web?" in result.output
+    assert run_aggregate.call_count == 2
+    assert push_to_remote.call_count == 2
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
`otools-pending clean` asked whether to re-aggregate once per touched submodule. Answering the same question over and over is annoying, and it also gets in the way of ever doing the aggregations concurrently, since the prompts have to happen before any concurrent work starts.

A single question is now asked, listing every submodule about to be re-aggregated:

```
Re-aggregate edi, stock-logistics-workflow, web? This may pull new changes from the remaining pending merges [y/n] (y):
```

`--aggregate` / `--no-aggregate` still skip the question entirely.

Along the way, removing a merged pull request from its merges file moves to `PendingPR.remove_from_merges_file()`, where the `is_patch` branch was already duplicated between the command and `Repo.purge_merged_prs()`.
