### PR TITLE
[REF] git: target repositories with cwd instead of chdir

### DIFF
--- a/odoo_tools/cli/submodule.py
+++ b/odoo_tools/cli/submodule.py
@@ -128,8 +128,7 @@ def sync_remote(submodule_path=None, repo=None, force_remote=False):
         if ui.ask_confirmation(
             f"Submodule {repo.name} has no pending merges. Update it to {odoo_version}?"
         ):
-            with path.cd(repo.abs_path):
-                git.checkout(branch_name=odoo_version)
+            git.checkout(branch_name=odoo_version, cwd=repo.abs_path)
 
 
 @cli.command()

--- a/odoo_tools/utils/git.py
+++ b/odoo_tools/utils/git.py
@@ -14,7 +14,7 @@ from git_autoshare.core import find_autoshare_repository
 from . import ui
 from .config import config as proj_config
 from .os_exec import run
-from .path import build_path, cd, root_path
+from .path import build_path, root_path
 from .proj import get_odoo_version, get_project_id
 
 
@@ -339,11 +339,11 @@ def submodule_update(path: str | PathLike):
 
 
 def submodule_set_url(repo_path, url, remote="origin"):
-    with cd(root_path()):
-        run(
-            ["git", "config", "--file=.gitmodules", f"submodule.{repo_path}.url", url],
-            check=True,
-        )
+    run(
+        ["git", "config", "--file=.gitmodules", f"submodule.{repo_path}.url", url],
+        cwd=root_path(),
+        check=True,
+    )
 
 
 def set_remote_url(repo_path, url, remote="origin", add=False):
@@ -351,13 +351,12 @@ def set_remote_url(repo_path, url, remote="origin", add=False):
     cmd = ["git", "remote", "set-url", remote, url]
     if add:
         cmd = ["git", "remote", "add", remote, url]
-    with cd(build_path(repo_path)):
-        run(cmd, check=True)
+    run(cmd, cwd=build_path(repo_path), check=True)
 
 
-def checkout(branch_name, remote="origin"):
-    run(["git", "fetch", remote, branch_name])
-    run(["git", "checkout", f"{remote}/{branch_name}"])
+def checkout(branch_name, remote="origin", cwd=None):
+    run(["git", "fetch", remote, branch_name], cwd=cwd)
+    run(["git", "checkout", f"{remote}/{branch_name}"], cwd=cwd)
 
 
 def get_current_branch():

--- a/odoo_tools/utils/path.py
+++ b/odoo_tools/utils/path.py
@@ -48,6 +48,13 @@ def build_path(path, from_root=True, from_file=None):
 
 @contextmanager
 def cd(path):
+    """Temporarily change the current working directory.
+
+    Beware: the working directory is process-global, so this is *not* safe to
+    use in code that may run concurrently -- it would change the directory
+    under the feet of the other threads, and with it what :func:`root_path`
+    resolves to. Pass ``cwd=`` to the command being run instead.
+    """
     prev = Path.cwd()
     os.chdir(Path(path).expanduser())
     try:

--- a/odoo_tools/utils/pending_merge.py
+++ b/odoo_tools/utils/pending_merge.py
@@ -17,7 +17,7 @@ from ..utils.misc import SmartDict, get_docker_image_commit_hashes
 from . import gh, git, ui
 from .config import config
 from .os_exec import run
-from .path import build_path, cd
+from .path import build_path
 from .proj import get_project_id, get_project_manifest_key
 from .yaml import (
     append_seq_item_with_comments,
@@ -625,8 +625,7 @@ class Repo:
                 # Sync submodule conf
                 ui.echo(f"Updating submodule conf: {opt.remote} -> {new_remote_url}")
                 git.submodule_set_url(self.path, new_remote_url, remote=opt.remote)
-            with cd(self.abs_path):
-                git.checkout(odoo_version, remote=opt.remote)
+            git.checkout(odoo_version, remote=opt.remote, cwd=self.abs_path)
         ui.echo("")
         if delete_file or ui.ask_confirmation(
             f"Delete pending merge file {self.abs_merges_path}?"

--- a/tests/common.py
+++ b/tests/common.py
@@ -1,7 +1,9 @@
 # Copyright 2023 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 import shutil
+from contextlib import contextmanager
 from pathlib import Path
+from unittest import mock
 
 import git
 import jinja2
@@ -23,6 +25,19 @@ def get_fixture_path(fname):
 
 def get_fixture(fname):
     return get_fixture_path(fname).read_text()
+
+
+@contextmanager
+def assert_no_chdir():
+    """Fail if the wrapped code changes the process working directory.
+
+    Anything that may run concurrently must pass ``cwd=`` to the commands it
+    runs rather than ``path.cd()``: the working directory is process-global,
+    so chdir'ing corrupts what ``root_path()`` resolves to for the other
+    threads. This guard makes such a regression fail loudly.
+    """
+    with mock.patch("os.chdir", side_effect=AssertionError("os.chdir() called")):
+        yield
 
 
 def mock_pypi_version_cache(pkg_name, version):

--- a/tests/test_utils_git.py
+++ b/tests/test_utils_git.py
@@ -11,8 +11,9 @@ import pytest
 from odoo_tools.exceptions import ProjectConfigException
 from odoo_tools.utils import git as git_utils
 from odoo_tools.utils import proj as proj_utils
+from odoo_tools.utils.path import build_path, root_path
 
-from .common import MockSubprocessRun, get_fixture_path
+from .common import MockSubprocessRun, assert_no_chdir, get_fixture_path
 
 # ── helpers ──────────────────────────────────────────────────────────────────
 
@@ -512,3 +513,45 @@ class TestGetCurrentBranch:
         repo = git.Repo(".")
         repo.create_head("my-feature").checkout()
         assert git_utils.get_current_branch() == "my-feature"
+
+
+# ── working directory safety ─────────────────────────────────────────────────
+#
+# These helpers run on submodules from code that may be executed concurrently
+# (e.g. the parallel aggregation of `otools-pending clean`), so they must
+# target a repository through `cwd=` rather than chdir'ing the whole process.
+
+
+def test_checkout_runs_in_given_cwd():
+    with mock.patch("odoo_tools.utils.git.run") as mock_run, assert_no_chdir():
+        git_utils.checkout("14.0", remote="OCA", cwd="/repo")
+    assert mock_run.call_args_list == [
+        mock.call(["git", "fetch", "OCA", "14.0"], cwd="/repo"),
+        mock.call(["git", "checkout", "OCA/14.0"], cwd="/repo"),
+    ]
+
+
+def test_submodule_set_url_runs_in_project_root(project):
+    with mock.patch("odoo_tools.utils.git.run") as mock_run, assert_no_chdir():
+        git_utils.submodule_set_url("odoo/external-src/edi", "git@github.com:OCA/edi")
+    mock_run.assert_called_once_with(
+        [
+            "git",
+            "config",
+            "--file=.gitmodules",
+            "submodule.odoo/external-src/edi.url",
+            "git@github.com:OCA/edi",
+        ],
+        cwd=root_path(),
+        check=True,
+    )
+
+
+def test_set_remote_url_runs_in_submodule(project):
+    with mock.patch("odoo_tools.utils.git.run") as mock_run, assert_no_chdir():
+        git_utils.set_remote_url("odoo/external-src/edi", "git@github.com:OCA/edi")
+    mock_run.assert_called_with(
+        ["git", "remote", "set-url", "origin", "git@github.com:OCA/edi"],
+        cwd=build_path("odoo/external-src/edi"),
+        check=True,
+    )

--- a/tests/test_utils_pending_merge.py
+++ b/tests/test_utils_pending_merge.py
@@ -15,7 +15,11 @@ from odoo_tools.exceptions import Exit, PathNotFound
 from odoo_tools.utils import pending_merge as pm_utils
 from odoo_tools.utils.config import config
 
-from .common import mock_pending_merge_repo_paths
+from .common import (
+    MockSubprocessRun,
+    assert_no_chdir,
+    mock_pending_merge_repo_paths,
+)
 
 Repo = pm_utils.Repo
 
@@ -846,6 +850,24 @@ def test_repo_push_to_remote(project):
         check=True,
         verbose=True,
     )
+
+
+def test_repo_aggregate_and_push_do_not_chdir(project):
+    """Aggregating and pushing must not change the process working directory:
+    they run concurrently, and chdir would corrupt the other threads' paths."""
+    mock_pending_merge_repo_paths("edi")
+    repo = Repo("edi", path_check=False)
+    subprocess_run = MockSubprocessRun(
+        [
+            {"args": None},  # gitaggregate
+            {"args": None},  # git remote get-url (remote_exists)
+            {"args": None},  # git push
+        ]
+    )
+    with mock.patch("subprocess.run", subprocess_run), assert_no_chdir():
+        repo.run_aggregate()
+        repo.push_to_remote(target_branch="merge-branch-1234-master-abc12345")
+    subprocess_run.assert_completed_calls()
 
 
 def _mock_clean_github_responses(


### PR DESCRIPTION
Several git helpers targeted a repository by `chdir`-ing into it for the duration of a command.

The working directory is process-global, so this is not thread-safe: it moves the directory under the feet of any other thread, and with it whatever `root_path()` resolves to. It is also simply unnecessary — every command involved takes a working directory.

`git.checkout()`, `git.submodule_set_url()` and `git.set_remote_url()` now pass `cwd=` to the command instead, and their callers pass the repository path down rather than wrapping the call in `path.cd()`.

Since this is an easy mistake to reintroduce, an `assert_no_chdir()` test guard fails on any `os.chdir()` in these code paths, and `path.cd()` documents why it must not be used in code that may run concurrently.
