### PR TITLE
[IMP] submodule upgrade: add --clean-pending and --aggregate options

### DIFF
--- a/odoo_tools/cli/submodule.py
+++ b/odoo_tools/cli/submodule.py
@@ -152,22 +152,46 @@ def push(submodule_path, target_branch=None):
 @click.option(
     "--force-branch", default=None, help="Force checkout of a specific branch"
 )
-def upgrade(submodule_path, force_branch):
+@click.option(
+    "--clean-pending/--no-clean-pending",
+    "clean_pending",
+    is_flag=True,
+    default=True,
+    help="Purge merged PRs from the pending merges of the submodules that have"
+    " some. This is the default behavior.",
+)
+@click.option(
+    "--aggregate/--no-aggregate",
+    "aggregate",
+    is_flag=True,
+    default=True,
+    help="Rebuild the consolidation branch of the submodules that still have"
+    " pending merges. This is the default behavior. With --no-aggregate, those"
+    " submodules are skipped.",
+)
+def upgrade(submodule_path, force_branch, clean_pending, aggregate):
     """Upgrade submodules to their latest remote commit.
 
     For submodules with pending merges, purge merged PRs first and
     re-aggregate if needed.
+
+    Both behaviors can be disabled independently: with --no-clean-pending the
+    pending merges are left as they are, and with --no-aggregate the submodules
+    that still have pending merges are skipped instead of being re-aggregated.
     """
     odoo_version = proj.get_project_manifest_key("odoo_version")
     ui.warn_missing_github_token()
     with path.cd(path.root_path()):
         for submodule in git.iter_gitmodules(filter_path=submodule_path):
             repo = pm_utils.Repo(submodule.path, path_check=False)
-            if repo.has_pending_merges():
+            if repo.has_pending_merges() and clean_pending:
                 ui.echo(f"Purging merged PRs for {submodule.path}")
                 for pr in repo.purge_merged_prs():
                     ui.echo(f"  removed {pr.shortcut}")
             if repo.has_pending_merges():
+                if not aggregate:
+                    ui.echo(f"Skipping {submodule.path}: it has pending merges")
+                    continue
                 ui.echo(f"Rebuilding consolidation branch for {submodule.path}")
                 repo.rebuild_consolidation_branch(push=True)
                 continue

--- a/tests/test_submodule.py
+++ b/tests/test_submodule.py
@@ -354,6 +354,60 @@ def test_upgrade_with_pending_merges(project):
         ".gitmodules": Path(get_fixture_path("fake-gitmodules")).read_text(),
     },
 )
+@pytest.mark.parametrize(
+    "options,expect_purge,expect_rebuild",
+    [
+        # re-aggregates without cleaning the pending merges
+        (["--no-clean-pending"], False, True),
+        # cleans the pending merges without re-aggregating
+        (["--no-aggregate"], True, False),
+        # completely ignores submodules with pending merges
+        (["--no-clean-pending", "--no-aggregate"], False, False),
+    ],
+)
+def test_upgrade_pending_merges_options(project, options, expect_purge, expect_rebuild):
+    with (
+        mock.patch.object(
+            submodule.pm_utils.Repo,
+            "has_pending_merges",
+            return_value=True,
+        ),
+        mock.patch.object(
+            submodule.pm_utils.Repo,
+            "has_any_pr_left",
+            return_value=True,
+        ),
+        mock.patch.object(
+            submodule.pm_utils.Repo, "purge_merged_prs", return_value=[]
+        ) as mock_purge,
+        mock.patch.object(
+            submodule.pm_utils.Repo, "rebuild_consolidation_branch"
+        ) as mock_rebuild,
+        mock.patch.object(submodule.git, "submodule_update") as mock_update,
+        mock.patch.object(submodule.git, "submodule_upgrade") as mock_upgrade,
+    ):
+        result = project.invoke(
+            submodule.upgrade,
+            ["odoo/external-src/account-closing", *options],
+            catch_exceptions=False,
+        )
+    assert result.exit_code == 0
+    assert mock_purge.called is expect_purge
+    assert mock_rebuild.called is expect_rebuild
+    # The submodule still has pending merges: it's never upgraded from remote.
+    mock_update.assert_not_called()
+    mock_upgrade.assert_not_called()
+    if not expect_rebuild:
+        assert "Skipping odoo/external-src/account-closing" in result.output
+
+
+@pytest.mark.project_setup(
+    manifest=dict(odoo_version="16.0"),
+    proj_version="16.0.1.2.3",
+    extra_files={
+        ".gitmodules": Path(get_fixture_path("fake-gitmodules")).read_text(),
+    },
+)
 def test_upgrade_pending_merges_all_purged(project):
     # Regression test for #252: when purging removes the last pending PR,
     # purge_merged_prs() already deletes the pending-merges file. The upgrade


### PR DESCRIPTION
## What

Adds two independent options to `otools-submodule upgrade`, both defaulting to `True` (current behavior):

- `--clean-pending/--no-clean-pending`: purge merged PRs from the pending merges of the submodules that have some.
- `--aggregate/--no-aggregate`: rebuild the consolidation branch of the submodules that still have pending merges.

They combine freely:

| Options | Behavior |
| --- | --- |
| `--clean-pending --aggregate` (default) | clean the pending merges and re-aggregate |
| `--no-clean-pending --aggregate` | re-aggregate without cleaning the pending merges |
| `--clean-pending --no-aggregate` | clean the pending merges without re-aggregating |
| `--no-clean-pending --no-aggregate` | completely ignore submodules with pending merges |

Submodules without pending merges are upgraded to their latest remote commit as before. If purging removes the last pending PR, the submodule no longer has pending merges and is upgraded from remote like any other one.

## Why

Sometimes you only want to upgrade the plain submodules and leave the aggregated ones alone, or clean up merged PRs without triggering a re-aggregation.

## Tests

Added `test_upgrade_pending_merges_options`, parametrized over the three non-default combinations, asserting which of the purge / consolidation rebuild / remote upgrade steps run.
