### PR TITLE
[FIX] submodule sync-remote: don't require a pending-merges file

### DIFF
--- a/odoo_tools/cli/submodule.py
+++ b/odoo_tools/cli/submodule.py
@@ -109,7 +109,7 @@ def sync_remote(submodule_path=None, repo=None, force_remote=False):
     """
 
     assert submodule_path or repo
-    repo = repo or pm_utils.Repo(submodule_path)
+    repo = repo or pm_utils.Repo(submodule_path, path_check=False)
 
     new_remote_url = pm_utils.get_new_remote_url(repo=repo, force_remote=force_remote)
 

--- a/tests/test_submodule.py
+++ b/tests/test_submodule.py
@@ -175,6 +175,94 @@ def test_push(project):
 @pytest.mark.project_setup(
     manifest=dict(odoo_version="16.0"),
     proj_version="16.0.1.2.3",
+)
+def test_sync_remote_no_pending_merges(project):
+    """A submodule without a pending-merges file is checked out on the version."""
+    new_remote_url = "git@github.com:OCA/some-repo.git"
+    mock_pending_merge_repo_paths("some-repo", src=True, pending=False)
+    mock_fn = MockSubprocessRun(
+        [
+            # set_remote_url -> submodule_set_url
+            {
+                "args": lambda args: (
+                    args[:2] == ["git", "config"] and args[-1] == new_remote_url
+                ),
+            },
+            # set_remote_url -> git remote set-url
+            {
+                "args": ["git", "remote", "set-url", "origin", new_remote_url],
+            },
+            # checkout -> git fetch
+            {
+                "args": ["git", "fetch", "origin", "16.0"],
+            },
+            # checkout -> git checkout
+            {
+                "args": ["git", "checkout", "origin/16.0"],
+            },
+        ]
+    )
+    with (
+        mock.patch("subprocess.run", mock_fn),
+        mock.patch.object(
+            submodule.pm_utils, "get_new_remote_url", return_value=new_remote_url
+        ),
+        mock.patch.object(submodule.ui, "ask_confirmation", return_value=True),
+    ):
+        result = project.invoke(
+            submodule.sync_remote,
+            ["odoo/external-src/some-repo"],
+            catch_exceptions=False,
+        )
+    assert result.exit_code == 0
+    mock_fn.assert_completed_calls()
+    assert f"is now being sourced from {new_remote_url}" in result.output
+
+
+@pytest.mark.project_setup(
+    manifest=dict(odoo_version="16.0"),
+    proj_version="16.0.1.2.3",
+)
+def test_sync_remote_with_pending_merges(project):
+    new_remote_url = "git@github.com:camptocamp/some-repo.git"
+    mock_pending_merge_repo_paths("some-repo", src=True, pending=True)
+    mock_fn = MockSubprocessRun(
+        [
+            # set_remote_url -> submodule_set_url
+            {
+                "args": lambda args: (
+                    args[:2] == ["git", "config"] and args[-1] == new_remote_url
+                ),
+            },
+            # set_remote_url -> git remote set-url
+            {
+                "args": ["git", "remote", "set-url", "origin", new_remote_url],
+            },
+        ]
+    )
+    with (
+        mock.patch("subprocess.run", mock_fn),
+        mock.patch.object(
+            submodule.pm_utils, "get_new_remote_url", return_value=new_remote_url
+        ),
+        mock.patch.object(submodule.ui, "ask_confirmation", return_value=True),
+        mock.patch.object(
+            submodule.pm_utils.Repo, "rebuild_consolidation_branch"
+        ) as mock_rebuild,
+    ):
+        result = project.invoke(
+            submodule.sync_remote,
+            ["odoo/external-src/some-repo"],
+            catch_exceptions=False,
+        )
+    assert result.exit_code == 0
+    mock_fn.assert_completed_calls()
+    mock_rebuild.assert_called_once_with(push=True)
+
+
+@pytest.mark.project_setup(
+    manifest=dict(odoo_version="16.0"),
+    proj_version="16.0.1.2.3",
     extra_files={
         ".gitmodules": Path(get_fixture_path("fake-gitmodules")).read_text(),
     },


### PR DESCRIPTION
Running `otools-submodule sync-remote` on a submodule that has no pending-merges file crashes, even though the command explicitly supports that case.

## Steps to reproduce

On a project where `odoo/src` has no pending-merges file:

```
$ otools-submodule sync-remote odoo/src
Traceback (most recent call last):
  File "~/.local/bin/otools-submodule", line 10, in <module>
    sys.exit(cli())
  [...click frames...]
  File "odoo_tools/cli/submodule.py", line 112, in sync_remote
    repo = repo or pm_utils.Repo(submodule_path)
                   ~~~~~~~~~~~~~^^^^^^^^^^^^^^^^
  File "odoo_tools/utils/pending_merge.py", line 129, in __init__
    self._check_paths()
    ~~~~~~~~~~~~~~~~~^^
  File "odoo_tools/utils/pending_merge.py", line 140, in _check_paths
    raise PathNotFound(f"MERGES PATH NOT FOUND `{self.abs_merges_path}'.")
odoo_tools.exceptions.PathNotFound: MERGES PATH NOT FOUND `/path/to/project/pending-merges.d/src.yml'.
```

## Cause

`sync_remote` builds its `Repo` with the default `path_check=True`, and `Repo._check_paths()` requires a pending-merges file to exist. That contradicts the command itself, which handles the no-pending-merges case a few lines below by offering to update the submodule to the project's Odoo version:

```python
else:
    odoo_version = proj.get_project_manifest_key("odoo_version")
    if ui.ask_confirmation(
        f"Submodule {repo.name} has no pending merges. Update it to {odoo_version}?"
    ):
        git.checkout(branch_name=odoo_version, cwd=repo.abs_path)
```

## Fix

Build the repo with `path_check=False`, like `submodule upgrade` already does.

Note this also drops the `.git` existence check, so a mistyped submodule path now fails on the first git call in that directory instead of aborting with `GIT CONFIG NOT FOUND`.

## Tests

Two tests added on `sync-remote`: without a pending-merges file (remote is set, submodule checked out on the project version) and with one (consolidation branch rebuilt).
