### PR TITLE
[REF] pending: simplify _handle_empty_merges_file

### DIFF
--- a/odoo_tools/cli/pending.py
+++ b/odoo_tools/cli/pending.py
@@ -209,7 +209,7 @@ def clean_pending(repo_paths=(), aggregate=None):
         if repo.has_any_pr_left():
             to_aggregate.append(repo)
         else:
-            repo._handle_empty_merges_file(delete_file=True)
+            repo._handle_empty_merges_file()
     if not to_aggregate:
         return
     # Re-aggregating performs an upgrade of the submodules, potentially pulling

--- a/odoo_tools/utils/pending_merge.py
+++ b/odoo_tools/utils/pending_merge.py
@@ -13,7 +13,7 @@ import requests
 from ruamel.yaml.comments import CommentedMap, CommentedSeq
 
 from ..exceptions import PathNotFound
-from ..utils.misc import SmartDict, get_docker_image_commit_hashes
+from ..utils.misc import get_docker_image_commit_hashes
 from . import gh, git, ui
 from .config import config
 from .os_exec import run
@@ -573,64 +573,33 @@ class Repo:
             pr.remove_from_merges_file()
             yield pr
         if not self.has_any_pr_left():
-            self._handle_empty_merges_file(delete_file=True)
+            self._handle_empty_merges_file()
 
-    def _handle_empty_merges_file(self, delete_file=False):
+    def _handle_empty_merges_file(self):
+        """Reset the submodule to the upstream branch and drop the merges file.
+
+        Called once the submodule has no pending merge left: its consolidation
+        branch is not needed anymore, so the submodule goes back to tracking
+        the upstream branch of the project's Odoo version.
+        """
         odoo_version = get_project_manifest_key("odoo_version")
-        ui.echo("")
-        update_options = [
-            SmartDict(choice="9", label="no update", remote="", ref=""),
-        ]
-        default_remote = "OCA"
         avail_remotes = list(self.merges_config()["remotes"].keys())
-        if "OCA" not in avail_remotes:
-            if self.company_git_remote in avail_remotes:
-                default_remote = self.company_git_remote
-            else:
-                ui.exit_msg("No OCA or company remote found in merges config.")
-
-        for i, remote in enumerate(avail_remotes, start=1):
-            ref = f"{remote}/{odoo_version}"
-            update_options.append(
-                SmartDict(
-                    choice=str(i),
-                    label=ref,
-                    remote=remote,
-                    ref=ref,
-                    default=remote == default_remote,
-                )
-            )
-        sorted_options = sorted(update_options, key=lambda x: x.choice)
-        default_choice = next(opt for opt in sorted_options if opt.default).choice
-        msg = (
-            f"Submodule {self.name} has no pending merges. "
-            f"Choose if/how to update:\n"
-            + "\n".join([f"  {opt.choice}) {opt.label} " for opt in sorted_options])
-            + "\n"
-        )
-        if delete_file:
-            choice = default_choice
+        if "OCA" in avail_remotes:
+            remote = "OCA"
+        elif self.company_git_remote in avail_remotes:
+            remote = self.company_git_remote
         else:
-            choice = ui.ask_question(msg, default=default_choice)
-        opt = next(opt for opt in sorted_options if opt.choice == choice)
-        if opt.remote:
-            remotes = git.get_remotes(self.abs_path)
-            new_remote_url = get_new_remote_url(repo=self, force_remote=opt.remote)
-            if opt.remote not in remotes:
-                ui.echo(f"Adding missing remote: {opt.remote} -> {new_remote_url}")
-                git.set_remote_url(
-                    self.path, new_remote_url, remote=opt.remote, add=True
-                )
-            else:
-                # Sync submodule conf
-                ui.echo(f"Updating submodule conf: {opt.remote} -> {new_remote_url}")
-                git.submodule_set_url(self.path, new_remote_url, remote=opt.remote)
-            git.checkout(odoo_version, remote=opt.remote, cwd=self.abs_path)
-        ui.echo("")
-        if delete_file or ui.ask_confirmation(
-            f"Delete pending merge file {self.abs_merges_path}?"
-        ):
-            self.abs_merges_path.unlink(missing_ok=True)
+            ui.exit_msg("No OCA or company remote found in merges config.")
+        new_remote_url = get_new_remote_url(repo=self, force_remote=remote)
+        if remote not in git.get_remotes(self.abs_path):
+            ui.echo(f"Adding missing remote: {remote} -> {new_remote_url}")
+            git.set_remote_url(self.path, new_remote_url, remote=remote, add=True)
+        else:
+            # Sync submodule conf
+            ui.echo(f"Updating submodule conf: {remote} -> {new_remote_url}")
+            git.submodule_set_url(self.path, new_remote_url, remote=remote)
+        git.checkout(odoo_version, remote=remote, cwd=self.abs_path)
+        self.abs_merges_path.unlink(missing_ok=True)
 
     def push_to_remote(self, target_branch=None):
         """Push the aggregated HEAD to the company remote as ``target_branch``.
@@ -719,7 +688,7 @@ def remove_pending(entity_url, aggregate=True):
     # check if that file is useless since it has an empty `merges` section
     # if it does - drop it instead of writing a new file version
     if not repo.has_any_pr_left():
-        repo._handle_empty_merges_file(delete_file=True)
+        repo._handle_empty_merges_file()
     elif aggregate:
         repo.run_aggregate()
     return repo

--- a/odoo_tools/utils/pending_merge.py
+++ b/odoo_tools/utils/pending_merge.py
@@ -592,11 +592,11 @@ class Repo:
             ui.exit_msg("No OCA or company remote found in merges config.")
         new_remote_url = get_new_remote_url(repo=self, force_remote=remote)
         if remote not in git.get_remotes(self.abs_path):
-            ui.echo(f"Adding missing remote: {remote} -> {new_remote_url}")
+            logger.debug("Adding missing remote: %s -> %s", remote, new_remote_url)
             git.set_remote_url(self.path, new_remote_url, remote=remote, add=True)
         else:
             # Sync submodule conf
-            ui.echo(f"Updating submodule conf: {remote} -> {new_remote_url}")
+            logger.debug("Updating submodule conf: %s -> %s", remote, new_remote_url)
             git.submodule_set_url(self.path, new_remote_url, remote=remote)
         git.checkout(odoo_version, remote=remote, cwd=self.abs_path)
         self.abs_merges_path.unlink(missing_ok=True)

--- a/tests/test_utils_pending_merge.py
+++ b/tests/test_utils_pending_merge.py
@@ -475,12 +475,13 @@ def test_handle_empty_merges_file_unlink_is_idempotent(project):
         mock.patch.object(
             Repo, "merges_config", return_value={"remotes": {"OCA": "url"}}
         ),
-        # "9" == "no update", so no remote/checkout git calls are triggered.
-        mock.patch.object(pm_utils.ui, "ask_question", return_value="9"),
-        mock.patch.object(pm_utils.ui, "ask_confirmation", return_value=True),
+        mock.patch.object(pm_utils, "get_new_remote_url", return_value="url"),
+        mock.patch.object(pm_utils.git, "get_remotes", return_value=["OCA"]),
+        mock.patch.object(pm_utils.git, "submodule_set_url"),
+        mock.patch.object(pm_utils.git, "checkout"),
     ):
         # The unlink must not raise FileNotFoundError for the missing file.
-        repo._handle_empty_merges_file(delete_file=False)
+        repo._handle_empty_merges_file()
 
 
 @pytest.mark.project_setup(manifest=dict(odoo_version="16.0"))


### PR DESCRIPTION
Two changes to `Repo._handle_empty_merges_file()`.

**Drop the `delete_file` argument.** All three call sites (`pending clean`, `pending remove`, `submodule upgrade`) pass `True`. The `False` branch was only reached by a test. That branch was the interactive one, so removing it drops the remote choice list, the prompt asking which branch to reset to, and the confirmation before deleting the merges file. What is left is what already happened in practice: pick the OCA remote, fall back to the company remote, then checkout and delete the file.

**Log the remote sync details instead of printing them.** "Adding missing remote" and "Updating submodule conf" are internal bookkeeping, so they are now `logger.debug` calls rather than `ui.echo`.

No behavior change for the three commands.
