### PR TITLE
[IMP] click: make --debug global and wire it to logging

### DIFF
--- a/odoo_tools/cli/cloud.py
+++ b/odoo_tools/cli/cloud.py
@@ -82,9 +82,8 @@ def get_celebrimbor_dump_list(platform=None, customer=None, env="int"):
 
 
 @click.group()
-@click.option("--debug", is_flag=True)
 @global_command_decorators
-def cli(**kwargs):
+def cli():
     """Cloud platform commands."""
     pass
 

--- a/odoo_tools/cli/db.py
+++ b/odoo_tools/cli/db.py
@@ -16,9 +16,8 @@ console = Console()
 
 
 @click.group()
-@click.option("--debug", is_flag=True)
 @utils.click.global_command_decorators
-def cli(**kwargs):
+def cli():
     """Database management commands."""
     pass
 

--- a/odoo_tools/cli/i18n.py
+++ b/odoo_tools/cli/i18n.py
@@ -48,9 +48,8 @@ def _build_odoo_i18n_export_cmd(module_name, language, database, export_path):
 
 
 @click.group()
-@click.option("--debug", is_flag=True)
 @utils.click.global_command_decorators
-def cli(**kwargs):
+def cli():
     """Internationalization (i18n) commands."""
     pass
 

--- a/odoo_tools/cli/password.py
+++ b/odoo_tools/cli/password.py
@@ -17,9 +17,8 @@ ODOO_PROJECT_URL = "https://{subdomain}.odoo.camptocamp.{country}"
 
 
 @click.group()
-@click.option("--debug", is_flag=True)
 @utils.click.global_command_decorators
-def cli(**kwargs):
+def cli():
     """Password management tools."""
 
 

--- a/odoo_tools/utils/click.py
+++ b/odoo_tools/utils/click.py
@@ -1,3 +1,4 @@
+import logging
 from collections.abc import Callable
 from functools import wraps
 
@@ -8,6 +9,7 @@ from .minimum_version import with_minimum_version_check
 from .update_check import with_update_check
 
 __all__ = [
+    "debug_option",
     "deprecated_option",
     "handle_exceptions",
     "global_command_decorators",
@@ -15,6 +17,11 @@ __all__ = [
     "with_minimum_version_check",
     "with_update_check",
 ]
+
+#: Key under which the ``--debug`` flag is stored in the click context meta.
+#: ``Context.meta`` is shared by the whole context tree, so a nested command
+#: can read the flag whether it was passed to the group or to the command.
+DEBUG_META_KEY = "odoo_tools.debug"
 
 
 def deprecated_option(*param_decls, message: str | None = None, **kwargs):
@@ -53,17 +60,47 @@ version_option = click.version_option(
 )
 
 
+def _enable_debug(ctx, param, value):
+    """Turn debug mode on as soon as the flag is parsed.
+
+    Debug mode both shows full stack traces (see `handle_exceptions`) and
+    routes the ``odoo_tools`` debug logs to stderr. The level is raised on our
+    own logger rather than on the root one, to keep third-party debug output
+    (urllib3 & friends) out of the way.
+    """
+    ctx.meta[DEBUG_META_KEY] = value
+    if value:
+        logging.basicConfig(format="%(levelname)s %(name)s: %(message)s")
+        logging.getLogger("odoo_tools").setLevel(logging.DEBUG)
+    return value
+
+
+#: The flag is eager so that logging is ready before any other callback runs,
+#: and unexposed so that it does not reach the command callbacks, which mostly
+#: take no argument at all.
+debug_option = click.option(
+    "--debug",
+    is_flag=True,
+    is_eager=True,
+    expose_value=False,
+    callback=_enable_debug,
+    help="Show full stack traces and log debug messages.",
+)
+
+
 def global_command_decorators(func):
     """Apply the standard ``otools-*`` pre-invoke hooks.
 
     Bundles (in order): update-available check, project ``otools_min_version``
-    enforcement, and the ``-V`` / ``--version`` flag. Place it right above
-    ``def cli(...):`` so it wraps the callback; ``@click.group()`` /
-    ``@click.command()`` and any CLI-specific options stay where they are.
+    enforcement, the ``-V`` / ``--version`` flag and the ``--debug`` flag.
+    Place it right above ``def cli(...):`` so it wraps the callback;
+    ``@click.group()`` / ``@click.command()`` and any CLI-specific options stay
+    where they are.
     """
     func = with_update_check(func)
     func = with_minimum_version_check(func)
     func = version_option(func)
+    func = debug_option(func)
     return func
 
 
@@ -74,12 +111,13 @@ def handle_exceptions() -> Callable:
     exceptions so that the full stack trace is shown.
     Otherwise, the exception is caught and a short error message is printed.
 
-    It can be used to wrap any click.command, e.g:
+    The flag comes from `global_command_decorators`, so it only needs to wrap
+    the command itself, e.g:
 
     .. code-block:: python
 
         @click.group()
-        @click.option("--debug", is_flag=True)
+        @global_command_decorators
         def cli():
             ...
 
@@ -96,6 +134,8 @@ def handle_exceptions() -> Callable:
             debug = (
                 # If ctx is None, it may be an early stage so we treat as debug mode
                 (ctx := click.get_current_context(silent=True)) is None
+                # Set by the global `--debug` flag, wherever it was passed
+                or ctx.meta.get(DEBUG_META_KEY)
                 # Check the current context (e.g: command options)
                 or ctx.params.get("debug")
                 # Check the root context (e.g: global options)

--- a/tests/test_utils_click.py
+++ b/tests/test_utils_click.py
@@ -1,0 +1,95 @@
+# Copyright 2026 Camptocamp SA (https://www.camptocamp.com).
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+import logging
+
+import click
+import pytest
+
+from odoo_tools.utils.click import global_command_decorators, handle_exceptions
+
+
+@pytest.fixture(autouse=True)
+def restore_logging():
+    """Keep the global logging state out of the other tests.
+
+    The `--debug` flag configures logging process-wide, which would otherwise
+    leak from one test to the next.
+    """
+    package_logger = logging.getLogger("odoo_tools")
+    level = package_logger.level
+    root_handlers = logging.getLogger().handlers[:]
+    yield
+    package_logger.setLevel(level)
+    logging.getLogger().handlers[:] = root_handlers
+
+
+@pytest.fixture()
+def cli():
+    """A CLI wired like the real ``otools-*`` ones."""
+
+    @click.group()
+    @global_command_decorators
+    def cli():
+        pass
+
+    @cli.command()
+    @handle_exceptions()
+    def emit():
+        logging.getLogger("odoo_tools.utils.testing").debug("a debug message")
+        logging.getLogger("urllib3.connectionpool").debug("third-party message")
+
+    @cli.command()
+    @handle_exceptions()
+    def boom():
+        raise ValueError("kaboom")
+
+    return cli
+
+
+def test_debug_option_is_available(cli, runner):
+    result = runner.invoke(cli, ["--help"])
+    assert result.exit_code == 0
+    assert "--debug" in result.output
+
+
+def test_debug_logs_are_hidden_by_default(cli, runner, caplog):
+    result = runner.invoke(cli, ["emit"], catch_exceptions=False)
+    assert result.exit_code == 0
+    assert "a debug message" not in caplog.text
+
+
+def test_debug_option_enables_package_debug_logs(cli, runner, caplog):
+    result = runner.invoke(cli, ["--debug", "emit"], catch_exceptions=False)
+    assert result.exit_code == 0
+    assert "a debug message" in caplog.text
+    # The level is raised on our own logger only, so that third-party debug
+    # output (urllib3 & friends) stays out of the way.
+    assert "third-party message" not in caplog.text
+
+
+def test_debug_option_sets_up_a_log_handler(cli, runner, monkeypatch):
+    """The flag must also give the logs somewhere to go.
+
+    Raising the level is not enough: without a handler the records are
+    discarded. That part cannot be asserted on the captured stderr, because
+    pytest has already put a handler on the root logger, which makes
+    `basicConfig` a no-op for the whole test suite.
+    """
+    calls = []
+    monkeypatch.setattr(logging, "basicConfig", lambda **kwargs: calls.append(kwargs))
+    result = runner.invoke(cli, ["--debug", "emit"], catch_exceptions=False)
+    assert result.exit_code == 0
+    assert calls
+
+
+def test_handle_exceptions_wraps_errors_by_default(cli, runner):
+    result = runner.invoke(cli, ["boom"])
+    assert result.exit_code == 1
+    assert "Failed to boom: kaboom" in result.output
+
+
+def test_debug_option_reraises_errors(cli, runner):
+    """The flag reaches `handle_exceptions` even though it is not exposed."""
+    result = runner.invoke(cli, ["--debug", "boom"])
+    assert isinstance(result.exception, ValueError)


### PR DESCRIPTION
Follow-up to #260, which moved two messages to `logger.debug`. There was no way to see them: logging is never configured, so every `logger.debug` call is discarded. The existing `--debug` flags only controlled whether `handle_exceptions` re-raised, and were declared on 4 CLIs out of 12.

Move `--debug` to `global_command_decorators`, so all 12 `otools-*` commands get it, and have it raise the level of the `odoo_tools` logger. The level goes on our own logger and not on the root one, to keep third-party debug output (urllib3 and friends) out of the way.

The flag stays unexposed and is read from `ctx.meta`, so the group callbacks keep their current signatures. The now-duplicate `--debug` options are removed from `cloud`, `db`, `i18n` and `password`.

```
otools-pending --debug clean
DEBUG odoo_tools.utils.pending_merge: Adding missing remote: OCA -> git@github.com:OCA/edi.git
```

`--debug` now means both "show tracebacks" and "log debug messages". Adds tests for `utils/click.py`, which had none.
