### PR TITLE
[FIX] pending: skip repos without pending merges instead of crashing

### DIFF
--- a/odoo_tools/cli/pending.py
+++ b/odoo_tools/cli/pending.py
@@ -28,10 +28,27 @@ def cli():
     pass
 
 
-def _resolve_repos(repo_paths, path_check=True):
+def _resolve_repos(repo_paths):
+    """Return the repos with a pending-merges file, among ``repo_paths`` if given.
+
+    Each given repo can be designated either by its path or by its name.
+    """
+    pending_repos = pm_utils.Repo.repositories_from_pending_folder(path_check=False)
     if not repo_paths:
-        return pm_utils.Repo.repositories_from_pending_folder(path_check=path_check)
-    return [pm_utils.Repo(repo_path, path_check=path_check) for repo_path in repo_paths]
+        return pending_repos
+    pending_repos_by_path = {repo.path: repo for repo in pending_repos}
+    repos = {}
+    for repo_path in repo_paths:
+        # Accept both a bare repo name and a submodule path
+        path = pm_utils.Repo(repo_path, path_check=False).path
+        if path not in pending_repos_by_path:
+            ui.err_console.print(
+                f"Warning: {repo_path} has no pending merges, skipping.",
+                style="yellow",
+            )
+            continue
+        repos[path] = pending_repos_by_path[path]
+    return list(repos.values())
 
 
 @cli.command(name="show")
@@ -61,7 +78,7 @@ def _resolve_repos(repo_paths, path_check=True):
 )
 def show_pending(repo_paths=(), check=True, as_json=False):
     """List pull requests on <repo_path>."""
-    repos = _resolve_repos(repo_paths, path_check=False)
+    repos = _resolve_repos(repo_paths)
     all_prs = [pr for repo in repos for pr in repo._iter_pending_pull_requests()]
     if check:
         ui.warn_missing_github_token()
@@ -247,10 +264,10 @@ def clean_pending(repo_paths=(), aggregate=None):
 )
 def aggregate(repo_path, target_branch=None, push=None):
     """Perform a git aggregation on <repo_path>."""
-    repo = pm_utils.Repo(repo_path)
-    repo.run_aggregate()
-    if push:
-        repo.push_to_remote(target_branch=target_branch)
+    for repo in _resolve_repos([repo_path]):
+        repo.run_aggregate()
+        if push:
+            repo.push_to_remote(target_branch=target_branch)
 
 
 @cli.command(name="add")

--- a/odoo_tools/cli/pending.py
+++ b/odoo_tools/cli/pending.py
@@ -246,9 +246,8 @@ def clean_pending(repo_paths=(), aggregate=None):
         repo.push_to_remote()
 
 
-# TODO: add tests
 @cli.command(name="aggregate")
-@click.argument("repo_path")
+@click.argument("repo_paths", nargs=-1, required=True)
 @click.option(
     "-t",
     "--target-branch",
@@ -262,9 +261,9 @@ def clean_pending(repo_paths=(), aggregate=None):
     default=True,
     help="push the result of the aggregation to a remote branch",
 )
-def aggregate(repo_path, target_branch=None, push=None):
-    """Perform a git aggregation on <repo_path>."""
-    for repo in _resolve_repos([repo_path]):
+def aggregate(repo_paths, target_branch=None, push=None):
+    """Perform a git aggregation on each <repo_path>."""
+    for repo in _resolve_repos(repo_paths):
         repo.run_aggregate()
         if push:
             repo.push_to_remote(target_branch=target_branch)

--- a/odoo_tools/cli/release.py
+++ b/odoo_tools/cli/release.py
@@ -181,11 +181,7 @@ def _push_aggregated_branches(version=None, force=False):
             "Your repository has local changes, are you sure you want to continue?"
         )
     company_git_remote = config.company_git_remote
-    repos = [
-        repo
-        for repo in Repo.repositories_from_pending_folder()
-        if repo.has_pending_merges()
-    ]
+    repos = Repo.repositories_from_pending_folder()
     if not repos:
         ui.echo("No repo to push")
         return

--- a/tests/test_utils_pending_merge.py
+++ b/tests/test_utils_pending_merge.py
@@ -846,6 +846,28 @@ def test_cli_aggregate(project):
     assert push_to_remote.called
 
 
+def test_cli_aggregate_multiple_repos(project):
+    """`otools-pending aggregate` accepts several repos at once, aggregating
+    each of them once, and skips the ones without pending merges."""
+    mock_pending_merge_repo_paths("edi")
+    mock_pending_merge_repo_paths("web")
+    mock_pending_merge_repo_paths("stock", pending=False)
+    with (
+        mock.patch.object(pm_utils.Repo, "run_aggregate") as run_aggregate,
+        mock.patch.object(pm_utils.Repo, "push_to_remote") as push_to_remote,
+    ):
+        result = project.invoke(
+            pending.aggregate,
+            ["edi", "odoo/external-src/web", "stock", "edi"],
+            catch_exceptions=False,
+        )
+    assert result.exit_code == 0
+    assert "Warning: stock has no pending merges, skipping." in result.output
+    # edi is given twice but aggregated once, stock is left out
+    assert run_aggregate.call_count == 2
+    assert push_to_remote.call_count == 2
+
+
 @pytest.mark.parametrize("repo_path", ["edi", "odoo/external-src/edi"])
 def test_cli_aggregate_repo_without_pending_merges(project, repo_path):
     """A repo without a pending-merges file has nothing to aggregate: it is

--- a/tests/test_utils_pending_merge.py
+++ b/tests/test_utils_pending_merge.py
@@ -834,6 +834,34 @@ def test_repo_run_aggregate_runs_gitaggregate_cli(project):
     )
 
 
+def test_cli_aggregate(project):
+    mock_pending_merge_repo_paths("edi")
+    with (
+        mock.patch.object(pm_utils.Repo, "run_aggregate") as run_aggregate,
+        mock.patch.object(pm_utils.Repo, "push_to_remote") as push_to_remote,
+    ):
+        result = project.invoke(pending.aggregate, ["edi"], catch_exceptions=False)
+    assert result.exit_code == 0
+    assert run_aggregate.called
+    assert push_to_remote.called
+
+
+@pytest.mark.parametrize("repo_path", ["edi", "odoo/external-src/edi"])
+def test_cli_aggregate_repo_without_pending_merges(project, repo_path):
+    """A repo without a pending-merges file has nothing to aggregate: it is
+    reported and skipped instead of blowing up."""
+    mock_pending_merge_repo_paths("edi", pending=False)
+    with (
+        mock.patch.object(pm_utils.Repo, "run_aggregate") as run_aggregate,
+        mock.patch.object(pm_utils.Repo, "push_to_remote") as push_to_remote,
+    ):
+        result = project.invoke(pending.aggregate, [repo_path], catch_exceptions=False)
+    assert result.exit_code == 0
+    assert f"Warning: {repo_path} has no pending merges, skipping." in result.output
+    assert not run_aggregate.called
+    assert not push_to_remote.called
+
+
 def test_repo_push_to_remote(project):
     mock_pending_merge_repo_paths("edi")
     repo = Repo("edi", path_check=False)


### PR DESCRIPTION
Running `otools-pending aggregate <repo>` on a repo without panding merges crashed with a traceback:

```
File "odoo_tools/utils/pending_merge.py", line 147, in _check_paths
    raise PathNotFound(f"MERGES PATH NOT FOUND `{self.abs_merges_path}'.")
odoo_tools.exceptions.PathNotFound: MERGES PATH NOT FOUND `.../pending-merges.d/web.yml'.
```

Instead, show a nicer warning

```
$ otools-pending aggregate web
Warning: web has no pending merges, skipping.
```
