### PR TITLE
[FIX] pending: keep the state indicator visible when titles overflow

### DIFF
--- a/odoo_tools/cli/pending.py
+++ b/odoo_tools/cli/pending.py
@@ -8,10 +8,10 @@ import arrow
 import click
 from rich.console import Console
 from rich.live import Live
-from rich.markup import escape
 from rich.prompt import Confirm
 from rich.spinner import Spinner
 from rich.table import Table
+from rich.text import Text
 
 from ..utils import pending_merge as pm_utils
 from ..utils import ui
@@ -84,6 +84,8 @@ def show_pending(repo_paths=(), check=True, as_json=False):
         ui.warn_missing_github_token()
     # ids of PRs whose enrichment failed -> error message
     errors: dict[int, str] = {}
+    # Shared by every row: a new one per rebuild would restart the animation
+    spinner = Spinner("dots")
     # In case of --json, output directly
     if as_json:
         if check:
@@ -103,22 +105,23 @@ def show_pending(repo_paths=(), check=True, as_json=False):
         grid.add_column(no_wrap=True)  # state dot / spinner
         grid.add_column(no_wrap=True)  # shortcut (linked)
         grid.add_column(no_wrap=True, style="dim")  # patch marker
-        grid.add_column(no_wrap=True, overflow="ellipsis")  # title
+        grid.add_column()  # title
         grid.add_column(no_wrap=True, justify="right", style="dim")  # last updated
         for pr in all_prs:
             if not check:
                 state_cell, updated, title = "-", "", ""
             elif id(pr) in errors:
-                state_cell = "[red]?[/]"
-                updated = ""
-                title = f"[red]{escape(errors[id(pr)])}[/]"
+                state_cell, updated = "[red]?[/]", ""
+                title = Text(
+                    errors[id(pr)], style="red", no_wrap=True, overflow="ellipsis"
+                )
             elif not pr.is_enriched:
-                state_cell, updated, title = Spinner("dots"), "", ""
+                state_cell, updated, title = spinner, "", ""
             else:
                 state = "merged" if pr.merged else pr.state
                 state_cell = f"[{PR_STATE_STYLES.get(state, 'white')}]●[/]"
                 updated = arrow.get(pr.updated_at).humanize() if pr.updated_at else ""
-                title = pr.title or ""
+                title = Text(pr.title or "", no_wrap=True, overflow="ellipsis")
             grid.add_row(
                 state_cell,
                 f"[link={pr.url}]{pr.shortcut}[/link]",
@@ -170,23 +173,27 @@ def clean_pending(repo_paths=(), aggregate=None):
     removed: set[int] = set()  # ids of PRs removed from their merges file
     # ids of PRs whose enrichment failed -> error message
     errors: dict[int, str] = {}
+    # Shared by every row: a new one per rebuild would restart the animation
+    spinner = Spinner("dots")
 
     def build_grid():
         grid = Table.grid(padding=(0, 1))
         grid.add_column(no_wrap=True)  # state dot / spinner
         grid.add_column(no_wrap=True)  # shortcut (linked)
         grid.add_column(no_wrap=True, style="dim")  # patch marker
-        grid.add_column(no_wrap=True, overflow="ellipsis")  # outcome
+        grid.add_column()  # outcome
         for pr in all_prs:
             if id(pr) in errors:
                 state_cell = "[red]?[/]"
-                outcome = f"[red]{escape(errors[id(pr)])}[/]"
+                outcome = Text(
+                    errors[id(pr)], style="red", no_wrap=True, overflow="ellipsis"
+                )
             elif not pr.is_enriched:
-                state_cell, outcome = Spinner("dots"), ""
+                state_cell, outcome = spinner, ""
             elif id(pr) in removed:
                 state = "merged" if pr.merged else pr.state
                 state_cell = f"[{PR_STATE_STYLES.get(state, 'white')}]●[/]"
-                outcome = "[green]removed[/]"
+                outcome = Text("removed", style="green")
             else:
                 continue  # enriched but not removed — nothing to do here
             grid.add_row(

--- a/odoo_tools/cli/release.py
+++ b/odoo_tools/cli/release.py
@@ -7,10 +7,10 @@ import click
 from git import Repo as GitRepo
 from rich.console import Console
 from rich.live import Live
-from rich.markup import escape
 from rich.prompt import Confirm
 from rich.spinner import Spinner
 from rich.table import Table
+from rich.text import Text
 
 from ..exceptions import ProjectConfigException
 from ..utils import gh, ui
@@ -186,20 +186,25 @@ def _push_aggregated_branches(version=None, force=False):
         ui.echo("No repo to push")
         return
     states = {}  # repo -> "done" | error message
+    # Shared by every row: a new one per rebuild would restart the animation
+    spinner = Spinner("dots")
 
     def build_grid():
         grid = Table.grid(padding=(0, 1))
         grid.add_column(no_wrap=True)  # state dot / spinner
-        grid.add_column(no_wrap=True, overflow="ellipsis")  # repo + outcome
+        grid.add_column()  # repo + outcome
         for repo in repos:
             state = states.get(repo)
-            path = repo.path.as_posix()
+            outcome = Text(repo.path.as_posix(), no_wrap=True, overflow="ellipsis")
             if state is None:
-                grid.add_row(Spinner("dots"), path)
+                state_cell = spinner
             elif state == "done":
-                grid.add_row("[green]●[/]", f"{path} [green]pushed {branch_name}[/]")
+                state_cell = "[green]●[/]"
+                outcome.append(f" pushed {branch_name}", style="green")
             else:
-                grid.add_row("[red]?[/]", f"{path} [red]{escape(state)}[/]")
+                state_cell = "[red]?[/]"
+                outcome.append(f" {state}", style="red")
+            grid.add_row(state_cell, outcome)
         return grid
 
     with (

--- a/tests/test_pending.py
+++ b/tests/test_pending.py
@@ -1,0 +1,62 @@
+# Copyright 2026 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+
+import responses
+
+from odoo_tools.cli import pending
+
+from .common import mock_pending_merge_repo_paths
+
+REPO_NAME = "edi-framework"
+# The pending-merges template used by the fixture declares these pull requests.
+PENDING_PR_NUMBERS = (774, 773, 663, 759)
+# Long enough to push the grid past the terminal width set below.
+LONG_TITLE = (
+    "[19.0][ADD] base_business_document_import_iban: to remove direct "
+    "base_iban dependency out of base_business_document_import"
+)
+
+
+def test_show_keeps_state_indicator_when_titles_overflow(project):
+    """Long titles must not squeeze the state indicator column out of the grid.
+
+    Rich shrinks the whole grid when it doesn't fit, so a wide title column used
+    to collapse the one-char indicator (and the last-updated column) to nothing.
+    """
+    mock_pending_merge_repo_paths(REPO_NAME)
+    with responses.RequestsMock() as mocked_responses:
+        for number in PENDING_PR_NUMBERS:
+            mocked_responses.add(
+                responses.GET,
+                f"https://api.github.com/repos/OCA/{REPO_NAME}/pulls/{number}",
+                json={
+                    "state": "open",
+                    "merged": False,
+                    "title": LONG_TITLE,
+                    "updated_at": "2026-07-01T10:00:00Z",
+                },
+            )
+        result = project.invoke(
+            pending.show_pending,
+            catch_exceptions=False,
+            # Narrow enough that the titles overflow the grid
+            env={"COLUMNS": "100", "GITHUB_TOKEN": "fake-token"},
+        )
+    assert result.exit_code == 0
+    rows = [line for line in result.output.splitlines() if line.strip()]
+    assert len(rows) == len(PENDING_PR_NUMBERS)
+    # Each row keeps its state indicator; the title is ellipsized instead
+    for line, number in zip(rows, PENDING_PR_NUMBERS, strict=True):
+        assert line.startswith("●"), line
+        assert f"OCA/{REPO_NAME}#{number}" in line, line
+        assert "…" in line, line
+
+
+def test_show_no_check_skips_github(project):
+    mock_pending_merge_repo_paths(REPO_NAME)
+    with responses.RequestsMock():  # would fail on any HTTP call
+        result = project.invoke(
+            pending.show_pending, ["--no-check"], catch_exceptions=False
+        )
+    assert result.exit_code == 0
+    assert f"OCA/{REPO_NAME}#774" in result.output

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -282,14 +282,19 @@ def test_bump_push_repo_with_pending_merge(project):
             ["minor", "--no-commit", "--no-tag"],
             catch_exceptions=False,
             input="y",
+            # Narrow enough that the grid rows overflow
+            env={"COLUMNS": "60"},
         )
     assert result.exit_code == 0
     assert ran_cmd == [
         "git config remote.camptocamp.url",
         "git push -f -v camptocamp HEAD:refs/heads/merge-branch-1234-14.0.0.2.0",
     ]
-    # the pushed repo shows up in the live progress grid
-    assert "edi-framework" in result.output
+    # the pushed repo shows up in the live progress grid, keeping its state
+    # indicator: an overflowing row must ellipsize instead of squeezing it out
+    assert "● odoo/external-src/edi-framework pushed merge-branch-1234-…" in (
+        result.output
+    )
 
 
 def test_get_new_release_notes(tmp_path):


### PR DESCRIPTION
`otools-pending show` renders a state indicator per pull request -- a spinner while the GitHub API is queried, then a dot colored by state (magenta merged, green open, red closed). In practice the spinners show for a second and then disappear for every row at once, as soon as the first titles arrive. The shortcut gets truncated and the last-updated column vanishes too:

```
OCA/edi#1362          [19.0][ADD] base_business_document_import_iban: to remove direct base_iban dependen…
OCA/product-attribut… [19.0][MIG] product_pricelist_alternative: Migration to 19.0
OCA/sale-blanket#45   [19.0][FIX] sale_blanket_order: Restored missing section options on sale order lines
```

Now only the title gives up width, so the indicator and the dates survive whatever the terminal size:

```
● OCA/edi#1362                [19.0][ADD] base_business_document_import_iban: to remove direct base…  3 days ago
● OCA/product-attribute#1899  [19.0][MIG] product_pricelist_alternative: Migration to 19.0           a month ago
● OCA/sale-blanket#45         [19.0][FIX] sale_blanket_order: Restored missing sect…                 2 weeks ago
```

`otools-pending clean` had the same latent problem with long error messages.


**Current:**
<img width="2092" height="734" alt="image" src="https://github.com/user-attachments/assets/9df31b68-45f9-454a-b2c0-f94f555e417c" />

**Fixed**
<img width="2096" height="490" alt="image" src="https://github.com/user-attachments/assets/14398ff2-793a-4f8b-ac8d-d28412bfddc9" />
