### PR TITLE
[IMP] add a --jobs option to control concurrency

### DIFF
--- a/odoo_tools/cli/pending.py
+++ b/odoo_tools/cli/pending.py
@@ -15,7 +15,12 @@ from rich.text import Text
 
 from ..utils import pending_merge as pm_utils
 from ..utils import ui
-from ..utils.click import deprecated_option, global_command_decorators
+from ..utils.click import (
+    DEFAULT_MAX_WORKERS,
+    deprecated_option,
+    global_command_decorators,
+    jobs_option,
+)
 
 console = Console()
 
@@ -71,12 +76,13 @@ def _resolve_repos(repo_paths):
     default=False,
     help="Output as JSON",
 )
+@jobs_option
 @deprecated_option(
     "--purge",
     message="`--purge` has been removed from `otools-pending show`. "
     "Use `otools-pending clean` instead.",
 )
-def show_pending(repo_paths=(), check=True, as_json=False):
+def show_pending(repo_paths=(), check=True, as_json=False, jobs=DEFAULT_MAX_WORKERS):
     """List pull requests on <repo_path>."""
     repos = _resolve_repos(repo_paths)
     all_prs = [pr for repo in repos for pr in repo._iter_pending_pull_requests()]
@@ -89,7 +95,7 @@ def show_pending(repo_paths=(), check=True, as_json=False):
     # In case of --json, output directly
     if as_json:
         if check:
-            with ThreadPoolExecutor(max_workers=8) as pool:
+            with ThreadPoolExecutor(max_workers=jobs) as pool:
                 futures = {pool.submit(pr.enrich_with_github): pr for pr in all_prs}
                 for future in as_completed(futures):
                     try:
@@ -134,7 +140,7 @@ def show_pending(repo_paths=(), check=True, as_json=False):
     if check and all_prs:
         with (
             Live(build_grid(), console=console, refresh_per_second=10) as live,
-            ThreadPoolExecutor(max_workers=8) as pool,
+            ThreadPoolExecutor(max_workers=jobs) as pool,
         ):
             futures = {pool.submit(pr.enrich_with_github): pr for pr in all_prs}
             for future in as_completed(futures):
@@ -162,7 +168,8 @@ def show_pending(repo_paths=(), check=True, as_json=False):
     help="Run git aggregate (and push) on each touched repo after purging. "
     "If not set, you will be prompted once.",
 )
-def clean_pending(repo_paths=(), aggregate=None):
+@jobs_option
+def clean_pending(repo_paths=(), aggregate=None, jobs=DEFAULT_MAX_WORKERS):
     """Remove merged pull requests from pending-merge files."""
     repos = _resolve_repos(repo_paths)
     all_prs = [pr for repo in repos for pr in repo._iter_pending_pull_requests()]
@@ -209,7 +216,7 @@ def clean_pending(repo_paths=(), aggregate=None):
     # (so concurrent yaml edits stay race-free).
     with (
         Live(build_grid(), console=console, refresh_per_second=10) as live,
-        ThreadPoolExecutor(max_workers=8) as pool,
+        ThreadPoolExecutor(max_workers=jobs) as pool,
     ):
         futures = {pool.submit(pr.enrich_with_github): pr for pr in all_prs}
         for future in as_completed(futures):

--- a/odoo_tools/cli/release.py
+++ b/odoo_tools/cli/release.py
@@ -14,7 +14,7 @@ from rich.text import Text
 
 from ..exceptions import ProjectConfigException
 from ..utils import gh, ui
-from ..utils.click import global_command_decorators
+from ..utils.click import DEFAULT_MAX_WORKERS, global_command_decorators, jobs_option
 from ..utils.config import config
 from ..utils.git import get_current_branch, tag_signing_enabled
 from ..utils.marabunta import MarabuntaFileHandler
@@ -167,12 +167,14 @@ def _push_repo_branch(repo, branch_name, company_git_remote):
     )
 
 
-def _push_aggregated_branches(version=None, force=False):
+def _push_aggregated_branches(
+    version=None, force=False, max_workers=DEFAULT_MAX_WORKERS
+):
     """Push the local aggregated (pending-merge) branches to the company remote.
 
     The branch name is composed of the project id and the version number. It is
     done when closing a release, so a new patch branch can be rebuilt from the
-    same commits if required. Repos are pushed in parallel.
+    same commits if required. Repos are pushed ``max_workers`` at a time.
     """
     version = version or get_current_version()
     branch_name = make_merge_branch_name(version)
@@ -209,7 +211,7 @@ def _push_aggregated_branches(version=None, force=False):
 
     with (
         Live(build_grid(), console=console, refresh_per_second=10) as live,
-        ThreadPoolExecutor(max_workers=8) as pool,
+        ThreadPoolExecutor(max_workers=max_workers) as pool,
     ):
         futures = {
             pool.submit(_push_repo_branch, repo, branch_name, company_git_remote): repo
@@ -254,12 +256,14 @@ def cli():
     default=None,
     help="Push the aggregated (pending-merge) branches to upstream.",
 )
+@jobs_option
 def bump(
     rel_type,
     new_version=None,
     do_commit=None,
     do_tag=None,
     push_aggregated_branches=None,
+    jobs=DEFAULT_MAX_WORKERS,
 ):
     """Prepare a new release"""
     # --tag requires --commit (only the explicit conflict is an error here;
@@ -289,7 +293,7 @@ def bump(
             "Push aggregated branches?", default=True
         )
     if push_aggregated_branches:
-        _push_aggregated_branches(version=new_version, force=True)
+        _push_aggregated_branches(version=new_version, force=True, max_workers=jobs)
     # Resolve the commit decision now that the release files are ready to review
     if do_commit is None:
         do_commit = Confirm.ask("Create the release commit?", default=True)

--- a/odoo_tools/utils/click.py
+++ b/odoo_tools/utils/click.py
@@ -9,11 +9,13 @@ from .minimum_version import with_minimum_version_check
 from .update_check import with_update_check
 
 __all__ = [
+    "DEFAULT_MAX_WORKERS",
     "debug_option",
     "deprecated_option",
     "handle_exceptions",
     "global_command_decorators",
     "is_debug",
+    "jobs_option",
     "version_option",
     "with_minimum_version_check",
     "with_update_check",
@@ -82,6 +84,21 @@ def deprecated_option(*param_decls, message: str | None = None, **kwargs):
 
 version_option = click.version_option(
     __version__, "-V", "--version", package_name="odoo-tools"
+)
+
+#: How much concurrency this project considers reasonable, by default.
+DEFAULT_MAX_WORKERS = 8
+
+#: Shared ``--jobs`` option for the commands that fan their work out over a
+#: thread pool. Pass it as ``max_workers``; ``--jobs 1`` runs everything
+#: sequentially, which is handy to get readable output or to debug a failure.
+jobs_option = click.option(
+    "--jobs",
+    "jobs",
+    type=click.IntRange(min=1),
+    default=DEFAULT_MAX_WORKERS,
+    show_default=True,
+    help="Number of operations to run in parallel.",
 )
 
 


### PR DESCRIPTION
The commands that fan their work out over a thread pool hardcoded `max_workers=8`, with no way to change it. It is now a `--jobs` option on `otools-pending show`, `otools-pending clean` and `otools-release bump`, sharing a single reusable click option and a single `DEFAULT_MAX_WORKERS` constant.

```
--jobs INTEGER RANGE  Number of operations to run in parallel.  [default: 8; x>=1]
```
