### PR TITLE
[IMP] submodule upgrade: resolve the target branch only once

### DIFF
--- a/odoo_tools/cli/submodule.py
+++ b/odoo_tools/cli/submodule.py
@@ -181,6 +181,8 @@ def upgrade(submodule_path, force_branch, clean_pending, aggregate):
     """
     odoo_version = proj.get_project_manifest_key("odoo_version")
     ui.warn_missing_github_token()
+    # Resolved lazily on the first push, then reused for the other submodules.
+    target_branch = None
     with path.cd(path.root_path()):
         for submodule in git.iter_gitmodules(filter_path=submodule_path):
             repo = pm_utils.Repo(submodule.path, path_check=False)
@@ -193,7 +195,10 @@ def upgrade(submodule_path, force_branch, clean_pending, aggregate):
                     ui.echo(f"Skipping {submodule.path}: it has pending merges")
                     continue
                 ui.echo(f"Rebuilding consolidation branch for {submodule.path}")
-                repo.rebuild_consolidation_branch(push=True)
+                target_branch = target_branch or pm_utils.gh.get_target_branch()
+                repo.rebuild_consolidation_branch(
+                    push=True, target_branch=target_branch
+                )
                 continue
             # No pending merges: upgrade to latest remote
             branch = force_branch

--- a/odoo_tools/utils/pending_merge.py
+++ b/odoo_tools/utils/pending_merge.py
@@ -621,10 +621,10 @@ class Repo:
             verbose=True,
         )
 
-    def rebuild_consolidation_branch(self, push=False):
+    def rebuild_consolidation_branch(self, push=False, target_branch=None):
         self.run_aggregate()
         if push:
-            self.push_to_remote()
+            self.push_to_remote(target_branch=target_branch)
 
 
 def add_pending(entity_url, aggregate=True, patch=False, push=True):

--- a/tests/test_submodule.py
+++ b/tests/test_submodule.py
@@ -424,6 +424,9 @@ def test_upgrade_with_pending_merges(project):
         mock.patch.object(
             submodule.pm_utils.Repo, "rebuild_consolidation_branch"
         ) as mock_rebuild,
+        mock.patch.object(
+            submodule.pm_utils.gh, "get_target_branch", return_value="merge-branch"
+        ),
     ):
         result = project.invoke(
             submodule.upgrade,
@@ -432,7 +435,86 @@ def test_upgrade_with_pending_merges(project):
         )
     assert result.exit_code == 0
     mock_purge.assert_called_once_with()
-    mock_rebuild.assert_called_once_with(push=True)
+    mock_rebuild.assert_called_once_with(push=True, target_branch="merge-branch")
+
+
+@pytest.mark.project_setup(
+    manifest=dict(odoo_version="16.0"),
+    proj_version="16.0.1.2.3",
+    extra_files={
+        ".gitmodules": Path(get_fixture_path("fake-gitmodules")).read_text(),
+    },
+)
+def test_upgrade_pending_merges_target_branch_resolved_once(project):
+    # The target branch depends on the project and its HEAD only, so it must be
+    # resolved once and reused, otherwise get_target_branch() asks to confirm
+    # the override once per submodule with pending merges.
+    with (
+        mock.patch.object(
+            submodule.pm_utils.Repo,
+            "has_pending_merges",
+            return_value=True,
+        ),
+        mock.patch.object(
+            submodule.pm_utils.Repo,
+            "has_any_pr_left",
+            return_value=True,
+        ),
+        mock.patch.object(submodule.pm_utils.Repo, "purge_merged_prs", return_value=[]),
+        mock.patch.object(
+            submodule.pm_utils.Repo, "rebuild_consolidation_branch"
+        ) as mock_rebuild,
+        mock.patch.object(
+            submodule.pm_utils.gh, "get_target_branch", return_value="merge-branch"
+        ) as mock_get_target_branch,
+    ):
+        result = project.invoke(
+            submodule.upgrade,
+            [],
+            catch_exceptions=False,
+        )
+    assert result.exit_code == 0
+    mock_get_target_branch.assert_called_once_with()
+    # The fixture has 2 submodules: both are re-aggregated with the same branch.
+    assert mock_rebuild.call_args_list == [
+        mock.call(push=True, target_branch="merge-branch"),
+        mock.call(push=True, target_branch="merge-branch"),
+    ]
+
+
+@pytest.mark.project_setup(
+    manifest=dict(odoo_version="16.0"),
+    proj_version="16.0.1.2.3",
+    extra_files={
+        ".gitmodules": Path(get_fixture_path("fake-gitmodules")).read_text(),
+    },
+)
+def test_upgrade_no_aggregate_never_resolves_target_branch(project):
+    # Nothing gets re-aggregated: the target branch must never be resolved, so
+    # that such a run never asks to confirm a branch override.
+    with (
+        mock.patch.object(
+            submodule.pm_utils.Repo,
+            "has_pending_merges",
+            return_value=True,
+        ),
+        mock.patch.object(
+            submodule.pm_utils.Repo,
+            "has_any_pr_left",
+            return_value=True,
+        ),
+        mock.patch.object(submodule.pm_utils.Repo, "purge_merged_prs", return_value=[]),
+        mock.patch.object(
+            submodule.pm_utils.gh, "get_target_branch"
+        ) as mock_get_target_branch,
+    ):
+        result = project.invoke(
+            submodule.upgrade,
+            ["--no-aggregate"],
+            catch_exceptions=False,
+        )
+    assert result.exit_code == 0
+    mock_get_target_branch.assert_not_called()
 
 
 @pytest.mark.project_setup(
@@ -471,6 +553,9 @@ def test_upgrade_pending_merges_options(project, options, expect_purge, expect_r
         mock.patch.object(
             submodule.pm_utils.Repo, "rebuild_consolidation_branch"
         ) as mock_rebuild,
+        mock.patch.object(
+            submodule.pm_utils.gh, "get_target_branch", return_value="merge-branch"
+        ),
         mock.patch.object(submodule.git, "submodule_update") as mock_update,
         mock.patch.object(submodule.git, "submodule_upgrade") as mock_upgrade,
     ):


### PR DESCRIPTION
Running `otools-submodule upgrade` from a project on `master` asks to confirm the branch override once per submodule with pending merges, always with the same answer:

```
Rebuilding consolidation branch for odoo/external-src/account-closing
You are on branch master. Please confirm override of target branch merge-branch-1234-master-abc12345 (y/N) y
...
Rebuilding consolidation branch for odoo/external-src/account-financial-reporting
You are on branch master. Please confirm override of target branch merge-branch-1234-master-abc12345 (y/N) y
```

The branch name only depends on the project and its HEAD, so it is now resolved once and reused for every submodule:

```
Rebuilding consolidation branch for odoo/external-src/account-closing
You are on branch master. Please confirm override of target branch merge-branch-1234-master-abc12345 (y/N) y
...
Rebuilding consolidation branch for odoo/external-src/account-financial-reporting
```

It is resolved lazily, on the first submodule that actually needs a push, so a run that re-aggregates nothing (e.g. `--no-aggregate`) never asks at all.