### PR TITLE
[FIX] pending: add the PR title and URL comments to patches

### DIFF
--- a/odoo_tools/utils/pending_merge.py
+++ b/odoo_tools/utils/pending_merge.py
@@ -100,15 +100,9 @@ class PendingPR:
         403, or a timeout/connection error) on failure; callers are expected to
         catch and decide how to surface it.
         """
-        api_url = (
-            f"https://api.github.com/repos/{self.owner}/{self.repo}/pulls/{self.pr}"
+        data = self._repo.api_get(
+            f"/pulls/{self.pr}", upstream=self.owner, repo=self.repo
         )
-        headers = {}
-        if token := os.environ.get("GITHUB_TOKEN"):
-            headers["Authorization"] = f"token {token}"
-        response = requests.get(api_url, headers=headers, timeout=30)
-        response.raise_for_status()
-        data = response.json()
         self.state = data.get("state") or ""
         self.merged = bool(data.get("merged"))
         self.labels = [label["name"] for label in data.get("labels") or []]
@@ -211,8 +205,27 @@ class Repo:
         with self.abs_merges_path.open("w") as fobj:
             yaml_dump(data, fobj)
 
-    def api_url(self, upstream=None):
-        return f"https://api.github.com/repos/{upstream or self.company_git_remote}/{self.name}"
+    def api_url(self, upstream=None, repo=None):
+        return f"https://api.github.com/repos/{upstream or self.company_git_remote}/{repo or self.name}"
+
+    def api_get(self, path="", upstream=None, repo=None) -> dict:
+        """Get ``path`` (eg. ``/pulls/1234``) under this repo's GitHub API
+        endpoint and return the decoded JSON.
+
+        Raises ``requests.RequestException`` (eg. ``HTTPError`` on a missing PR
+        or a rate-limit 403, or a timeout/connection error) on failure; callers
+        are expected to catch and decide how to surface it.
+        """
+        headers = {}
+        if token := os.environ.get("GITHUB_TOKEN"):
+            headers["Authorization"] = f"token {token}"
+        response = requests.get(
+            self.api_url(upstream=upstream, repo=repo) + path,
+            headers=headers,
+            timeout=30,
+        )
+        response.raise_for_status()
+        return response.json()
 
     def ssh_url(self, namespace=None):
         namespace = namespace or self.company_git_remote
@@ -303,15 +316,50 @@ class Repo:
         config["merges"][0] = f"{upstream} {hashes[self.name.lower()]}"
         self.update_merges_config(config)
 
-    def add_pending_pull_request(self, upstream, pull_id):
+    def add_pending_pull_request(self, upstream, pull_id, patch=False):
+        """Add a pending pull request"""
         # TODO: proj_tmpl_ver=2 is deprecated
         if self.template_version == 2 and self.name.lower() in ("odoo", "enterprise"):
             ui.exit_msg(
                 "Sorry, adding a pending Pull Request to Odoo repositories is not "
                 "supported. Please add a pending commit instead."
             )
+        if patch:
+            return self._add_pending_pull_request_patch(upstream, pull_id)
+        return self._add_pending_pull_request(upstream, pull_id)
+
+    def _prepare_pending_pull_request_comment_lines(
+        self, upstream, pull_id
+    ) -> list[str]:
+        """Return the comment lines describing a pending pull request.
+
+        The PR title and URL are fetched from GitHub to be written on the
+        comment lines above the pending merge entry. The same call validates
+        that the PR targets the project's major version; when it fails we
+        simply skip the comment (and the branch validation).
+        """
+        try:
+            data = self.api_get(f"/pulls/{pull_id}", upstream=upstream)
+        except requests.RequestException as exc:
+            ui.echo(
+                f"Github API call failed ({exc}): skipping target branch validation."
+            )
+            return []
+        base_branch = data.get("base", {}).get("ref")
+        if base_branch and base_branch != get_project_manifest_key("odoo_version"):
+            ui.ask_or_abort(
+                "Requested PR targets branch different from"
+                " current project's major version. Proceed?"
+            )
+        comment = []
+        if title := data.get("title"):
+            comment.append(title)
+        if pr_url := data.get("html_url"):
+            comment.append(pr_url)
+        return comment
+
+    def _add_pending_pull_request(self, upstream, pull_id):
         conf = self.merges_config()
-        odoo_version = get_project_manifest_key("odoo_version")
         pending_mrg_line = f"{upstream} refs/pull/{pull_id}/head"
         if pending_mrg_line in conf.get("merges", {}):
             ui.echo(
@@ -319,30 +367,7 @@ class Repo:
             )
             return True
 
-        response = requests.get(f"{self.api_url(upstream=upstream)}/pulls/{pull_id}")
-
-        # TODO: auth
-        data = response.json()
-        base_branch = data.get("base", {}).get("ref")
-        # Describe the new pending merge with its title + URL on the comment
-        # lines above it, fetched from GitHub. When the call fails we simply skip
-        # the comment (and the branch validation).
-        comment = []
-        if response.ok:
-            if base_branch and base_branch != odoo_version:
-                ui.ask_or_abort(
-                    "Requested PR targets branch different from"
-                    " current project's major version. Proceed?"
-                )
-            if title := data.get("title"):
-                comment.append(title)
-            if pr_url := data.get("html_url"):
-                comment.append(pr_url)
-        else:
-            ui.echo(
-                f"Github API call failed ({response.status_code}):"
-                " skipping target branch validation."
-            )
+        comment = self._prepare_pending_pull_request_comment_lines(upstream, pull_id)
 
         known_remotes = conf["remotes"]
         if upstream not in known_remotes:
@@ -359,19 +384,32 @@ class Repo:
         self.update_merges_config(conf)
         return True
 
-    def add_pending_pull_request_patch(self, upstream, entity_url):
+    def _add_pending_pull_request_patch(self, upstream, pull_id):
         conf = self.merges_config()
-        line = f"curl -sSL {entity_url} | git am -3 --keep-non-patch --exclude '*requirements.txt'"
-        patches = self.merges_config().get("shell_command_after") or []
+        patch_url = f"https://github.com/{upstream}/{self.name}/pull/{pull_id}.patch"
+        line = f"curl -sSL {patch_url} | git am -3 --keep-non-patch --exclude '*requirements.txt'"
+        patches = conf.get("shell_command_after") or CommentedSeq()
         if line in patches:
             ui.echo(
-                f"{self.abs_merges_path} already contains a reference to {entity_url}"
+                f"{self.abs_merges_path} already contains a reference to {patch_url}"
             )
-            return
-        patches.append(line)
+            return True
+
+        comment = self._prepare_pending_pull_request_comment_lines(upstream, pull_id)
+
+        # Append the new patch at the end of the list, keeping the comment
+        # blocks of the existing entries anchored to them, and aligning the new
+        # comment with the shell command items.
+        append_seq_item_with_comments(
+            patches,
+            line,
+            comment=comment,
+            comment_indent=sequence_item_indent(),
+        )
         conf["shell_command_after"] = patches
         self.update_merges_config(conf)
-        ui.echo(f"📋 patch {entity_url} has been added")
+        ui.echo(f"📋 patch {patch_url} has been added")
+        return True
 
     def _get_pending_commit_lines(self, upstream: str, commit_sha: str):
         """Return the lines to add to the merges file for a given commit."""
@@ -655,14 +693,11 @@ def add_pending(entity_url, aggregate=True, patch=False, push=True):
         repo.update_pending_merges_file_base_merge()
 
     if entity_type == "pull":
-        if entity_url.endswith(".patch"):
+        # A ``.patch`` URL implies --patch, and is stripped to get the bare PR id
+        if entity_id.endswith(".patch"):
             patch = True
-        elif patch and not entity_url.endswith(".patch"):
-            entity_url += ".patch"
-        if patch:
-            repo.add_pending_pull_request_patch(upstream, entity_url)
-        else:
-            repo.add_pending_pull_request(upstream, entity_id)
+            entity_id = entity_id.removesuffix(".patch")
+        repo.add_pending_pull_request(upstream, entity_id, patch=patch)
     elif entity_type in ("commit", "tree"):
         repo.add_pending_commit(upstream, entity_id)
     if aggregate:
@@ -723,16 +758,9 @@ def get_new_remote_url(repo: Repo, force_remote: str | bool = False):
     else:
         # resolve what's the parent repository
         # from which company remote consolidation was forked
-        response = requests.get(repo.api_url())
-        if response.ok:
-            info = response.json()
-            parent = info.get("parent", {})
-            if parent:
-                new_remote_url = parent.get("ssh_url")
-            else:
-                # not a forked repo (eg: camptocamp/connector-jira)
-                new_remote_url = info.get("ssh_url")
-        else:
+        try:
+            info = repo.api_get()
+        except requests.RequestException:
             ui.echo(
                 "Couldn't reach Github API to resolve submodule upstream."
                 " Please provide it manually."
@@ -741,5 +769,12 @@ def get_new_remote_url(repo: Repo, force_remote: str | bool = False):
             new_namespace = input("Namespace [OCA]: ") or "OCA"
             new_repo = input(f"Repo name [{default_repo}]: ") or default_repo
             new_remote_url = Repo.build_ssh_url(new_namespace, new_repo)
+        else:
+            parent = info.get("parent", {})
+            if parent:
+                new_remote_url = parent.get("ssh_url")
+            else:
+                # not a forked repo (eg: camptocamp/connector-jira)
+                new_remote_url = info.get("ssh_url")
 
     return new_remote_url

--- a/odoo_tools/utils/yaml.py
+++ b/odoo_tools/utils/yaml.py
@@ -10,6 +10,11 @@ from ruamel.yaml.tokens import CommentToken
 
 yaml = YAML()
 
+# Never fold long scalars: the `curl ... | git am` patch commands of the
+# pending-merges files are way past the default width, and wrapping them
+# rewrites lines we did not touch, for a noisy diff.
+yaml.width = 2**16
+
 
 def yaml_load(stream):
     return yaml.load(stream)
@@ -64,7 +69,15 @@ def _normalize_seq_comments(seq):
             above[i + 1] = rest
     start = seq.ca.comment
     if start and start[1]:
-        above[0] = "".join(token.value for token in start[1] if token is not None)
+        # Unlike the per-item tokens, whose block part carries its own
+        # indentation inside the value, a start comment holds the plain ``#``
+        # line and keeps its column in the token's mark: bring it back into the
+        # value so the block is rebuilt at the same indentation.
+        above[0] = "".join(
+            " " * token.start_mark.column + token.value
+            for token in start[1]
+            if token is not None
+        )
     return eol, above
 
 

--- a/tests/test_utils_pending_merge.py
+++ b/tests/test_utils_pending_merge.py
@@ -713,33 +713,110 @@ def test_remove_pending_patch_v1():
 @pytest.mark.usefixtures("project")
 @pytest.mark.project_setup(proj_tmpl_ver=1)
 def test_add_pending_pull_request_patch():
+    """A patch is appended at the end of `shell_command_after`, either from a
+    `.patch` URL or with `patch=True`, with its PR title and URL on the comment
+    lines above it, just like a regular pending merge."""
     name = "edi"
-    tmpl = """
-    ../{ext_src_rel_path}/{repo_name}:
-        remotes:
-            camptocamp: git@github.com:camptocamp/{repo_name}.git
-            {org_name}: git@github.com:{org_name}/{repo_name}.git
-        target: camptocamp merge-branch-{pid}-master
-        merges:
-        - {org_name} 14.0
-        shell_command_after:
-        - curl -sSL https://github.com/OCA/edi/pull/1469.patch | git am -3 --keep-non-patch --exclude '*requirements.txt'"
-    """
+    tmpl = """\
+../{ext_src_rel_path}/{repo_name}:
+  remotes:
+    camptocamp: git@github.com:camptocamp/{repo_name}.git
+    {org_name}: git@github.com:{org_name}/{repo_name}.git
+  target: camptocamp merge-branch-{pid}-master
+  merges:
+    - {org_name} 14.0
+  shell_command_after:
+    # [14.0] [FIX] edi: fix 1469
+    # https://github.com/OCA/edi/pull/1469
+    - curl -sSL https://github.com/OCA/edi/pull/1469.patch | git am -3 --keep-non-patch --exclude '*requirements.txt'
+"""
     mock_pending_merge_repo_paths(name, tmpl=tmpl)
     repo = Repo(name, path_check=False)
-    pm_utils.add_pending(
-        "https://github.com/OCA/edi/pull/1470.patch",
-        aggregate=False,
+    with responses.RequestsMock() as rsps:
+        for pid in (1470, 1471):
+            rsps.add(
+                responses.GET,
+                f"https://api.github.com/repos/OCA/edi/pulls/{pid}",
+                json={
+                    "title": f"[14.0] [FIX] edi: fix {pid}",
+                    "html_url": f"https://github.com/OCA/edi/pull/{pid}",
+                    # match the project's odoo_version so no divergent-branch prompt
+                    "base": {"ref": "14.0"},
+                },
+                status=200,
+            )
+        pm_utils.add_pending(
+            "https://github.com/OCA/edi/pull/1470.patch",
+            aggregate=False,
+        )
+        pm_utils.add_pending(
+            "https://github.com/OCA/edi/pull/1471",
+            patch=True,
+            aggregate=False,
+        )
+    expected = dedent(
+        """\
+        ../odoo/external-src/edi:
+          remotes:
+            camptocamp: git@github.com:camptocamp/edi.git
+            OCA: git@github.com:OCA/edi.git
+          target: camptocamp merge-branch-1234-master
+          merges:
+            - OCA 14.0
+          shell_command_after:
+            # [14.0] [FIX] edi: fix 1469
+            # https://github.com/OCA/edi/pull/1469
+            - curl -sSL https://github.com/OCA/edi/pull/1469.patch | git am -3 --keep-non-patch --exclude '*requirements.txt'
+            # [14.0] [FIX] edi: fix 1470
+            # https://github.com/OCA/edi/pull/1470
+            - curl -sSL https://github.com/OCA/edi/pull/1470.patch | git am -3 --keep-non-patch --exclude '*requirements.txt'
+            # [14.0] [FIX] edi: fix 1471
+            # https://github.com/OCA/edi/pull/1471
+            - curl -sSL https://github.com/OCA/edi/pull/1471.patch | git am -3 --keep-non-patch --exclude '*requirements.txt'
+        """
     )
-    pm_utils.add_pending(
-        "https://github.com/OCA/edi/pull/1471",
-        patch=True,
-        aggregate=False,
+    assert repo.abs_merges_path.read_text() == expected
+
+
+@pytest.mark.usefixtures("project")
+@pytest.mark.project_setup(proj_tmpl_ver=1)
+def test_add_pending_pull_request_patch_without_title_no_comment():
+    """When the GitHub call fails, the patch is still appended at the end but
+    with no comment block (graceful degradation)."""
+    name = "edi"
+    tmpl = """\
+../{ext_src_rel_path}/{repo_name}:
+  remotes:
+    camptocamp: git@github.com:camptocamp/{repo_name}.git
+    {org_name}: git@github.com:{org_name}/{repo_name}.git
+  target: camptocamp merge-branch-{pid}-master
+  merges:
+    - {org_name} 14.0
+"""
+    mock_pending_merge_repo_paths(name, tmpl=tmpl)
+    repo = Repo(name, path_check=False)
+    with responses.RequestsMock() as rsps:
+        rsps.add(
+            responses.GET,
+            "https://api.github.com/repos/OCA/edi/pulls/1470",
+            json={"message": "Not Found"},
+            status=404,
+        )
+        repo.add_pending_pull_request("OCA", "1470", patch=True)
+    expected = dedent(
+        """\
+        ../odoo/external-src/edi:
+          remotes:
+            camptocamp: git@github.com:camptocamp/edi.git
+            OCA: git@github.com:OCA/edi.git
+          target: camptocamp merge-branch-1234-master
+          merges:
+            - OCA 14.0
+          shell_command_after:
+            - curl -sSL https://github.com/OCA/edi/pull/1470.patch | git am -3 --keep-non-patch --exclude '*requirements.txt'
+        """
     )
-    shell_command_after = repo.merges_config().get("shell_command_after", [])
-    line_tmpl = "curl -sSL https://github.com/OCA/edi/pull/{}.patch | git am -3 --keep-non-patch --exclude '*requirements.txt'"
-    for pid in (1470, 1471):
-        assert line_tmpl.format(pid) in shell_command_after, shell_command_after
+    assert repo.abs_merges_path.read_text() == expected
 
 
 def test_cli_add_multiple_urls(project):

--- a/tests/test_utils_yaml.py
+++ b/tests/test_utils_yaml.py
@@ -506,6 +506,41 @@ class TestAppendSeqItemWithComments:
         expected = "items:\n- a\n    # title\n- b\n"
         assert result == expected
 
+    def test_append_keeps_leading_comment_indentation(self):
+        """The block comment above the *first* item keeps its indentation: it is
+        the only one whose column ruamel stores on the token's mark rather than
+        inside its value, so it has to be restored by hand."""
+        src = dedent(
+            """\
+            pending:
+              items:
+                # comment for a
+                - a
+            """
+        )
+        loader = YAML()
+        loader.indent(mapping=2, sequence=4, offset=2)
+        data = loader.load(src)
+        append_seq_item_with_comments(
+            data["pending"]["items"],
+            "b",
+            comment=["comment for b"],
+            comment_indent="    ",
+        )
+        buf = io.StringIO()
+        loader.dump(data, buf)
+        expected = dedent(
+            """\
+            pending:
+              items:
+                # comment for a
+                - a
+                # comment for b
+                - b
+            """
+        )
+        assert buf.getvalue() == expected
+
     def test_append_without_comment_unchanged(self):
         """``comment=None`` still appends with no comment block."""
         src = dedent(


### PR DESCRIPTION
Adding a pending merge as a patch wrote the `curl | git am` line alone, leaving the entry unidentifiable:

```yaml
  shell_command_after:
    - curl -sSL https://github.com/OCA/edi/pull/1470.patch | git am -3 --keep-non-patch --exclude '*requirements.txt'
```

It now gets the PR title and URL on the comment lines above it, like a regular pending merge does:

```yaml
  shell_command_after:
    # [14.0] [FIX] edi: fix the thing
    # https://github.com/OCA/edi/pull/1470
    - curl -sSL https://github.com/OCA/edi/pull/1470.patch | git am -3 --keep-non-patch --exclude '*requirements.txt'
```

`--patch` also gets the target branch validation it was missing.
