### PR TITLE
[FIX] release: don't let untracked files block the bump

### DIFF
--- a/odoo_tools/cli/release.py
+++ b/odoo_tools/cli/release.py
@@ -276,7 +276,7 @@ def bump(
     # Warn about deprecated .bumpversion.cfg file
     _warn_deprecated_bumpversion_cfg()
     # Fail early on a dirty tree when we (likely) intend to commit
-    if do_commit is not False and repo.is_dirty(untracked_files=True):
+    if do_commit is not False and repo.is_dirty(untracked_files=False):
         raise click.ClickException(
             "There are uncommitted changes in the working tree. "
             "Commit or stash them before running `bump`."
@@ -299,7 +299,7 @@ def bump(
         do_commit = Confirm.ask("Create the release commit?", default=True)
     if do_commit:
         # Everything modified by the release process must be staged at this point
-        if repo.is_dirty(index=False, untracked_files=True):
+        if repo.is_dirty(index=False, untracked_files=False):
             raise click.ClickException(
                 "Unexpected changes left in the working tree after staging the "
                 "release files; aborting."

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -545,3 +545,27 @@ def test_bump_fails_on_unstaged_changes(project):
     assert "uncommitted changes" in result.output.lower()
     # The release did not proceed
     assert ver_file.read_text() == "14.0.0.1.0"
+
+
+@pytest.mark.project_setup(
+    proj_version="14.0.0.1.0", mock_marabunta_file=True, git_init=True
+)
+def test_bump_ignores_untracked_files(project):
+    project.invoke(init, catch_exceptions=False)
+    git_commit_all()
+    # Untracked files never end up in the release commit, so they must not block it
+    Path("AGENTS.md").write_text("Some local notes\n")
+    Path("tmp").mkdir()
+    (Path("tmp") / "scratch.txt").write_text("scratch\n")
+    result = project.invoke(
+        release.bump,
+        ["minor", "--commit", "--no-tag"],
+        catch_exceptions=False,
+        input="n",
+    )
+    assert result.exit_code == 0
+    assert '✅ Committed "Release 14.0.0.2.0"' in result.output
+    repo = git.Repo(".")
+    # The untracked files were left alone, not swept into the release commit
+    assert "AGENTS.md" not in repo.head.commit.stats.files
+    assert set(repo.untracked_files) == {"AGENTS.md", "tmp/scratch.txt"}


### PR DESCRIPTION
`otools-release bump` refused to run when the working tree only had untracked files:

```
$ otools-release bump patch
Error: There are uncommitted changes in the working tree. Commit or stash them before running `bump`.

$ git status
On branch master
Your branch is up to date with 'origin/master'.

Untracked files:
	.github/skills/
	AGENTS.md
	tmp/

nothing added to commit but untracked files present
```

Untracked files never end up in the release commit, and `git stash` skips them, so the only way out was to delete them.

Now the clean tree check only looks at staged and unstaged changes to tracked files. Untracked files are left alone and the bump goes through.

Closes #269
